### PR TITLE
Initial version of the API function to update and query migrated infrastructure cost information in AWS.

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -16,6 +16,162 @@ const docTemplate = `{
     "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
+        "/api/v1/cost/info": {
+            "get": {
+                "description": "Retrieve cost information for specified parameters within a defined date range. The date range must be within a 6-month period. Optionally, you can specify cost aggregation type and date order for the results.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[Cost Management]"
+                ],
+                "summary": "Get Cost Information",
+                "operationId": "GetCostInfo",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Start date for the cost information retrieval in 'YYYY-MM-DD' format",
+                        "name": "startDate",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "End date for the cost information retrieval in 'YYYY-MM-DD' format",
+                        "name": "endDate",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "csv",
+                        "description": "List of migration IDs to filter the cost information",
+                        "name": "migrationIds",
+                        "in": "query"
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "csv",
+                        "description": "List of cloud providers to filter the cost information",
+                        "name": "provider",
+                        "in": "query"
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "csv",
+                        "description": "List of resource types to filter the cost information",
+                        "name": "resourceTypes",
+                        "in": "query"
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "csv",
+                        "description": "List of resource IDs to filter the cost information",
+                        "name": "resourceIds",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Type of cost aggregation for the results (e.g., 'daily', 'weekly', 'monthly')",
+                        "name": "costAggregationType",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Order of dates in the result (e.g., 'asc', 'desc')",
+                        "name": "dateOrder",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Order of resource types in the result (e.g., 'asc', 'desc')",
+                        "name": "resourceTypeOrder",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully retrieved cost information",
+                        "schema": {
+                            "$ref": "#/definitions/app.AntResponse-array_cost_GetCostInfoResult"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request parameters",
+                        "schema": {
+                            "$ref": "#/definitions/app.AntResponse-string"
+                        }
+                    },
+                    "500": {
+                        "description": "Failed to retrieve cost information",
+                        "schema": {
+                            "$ref": "#/definitions/app.AntResponse-string"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Update cost information for specified resources, including details such as migration ID, cost resources, and additional AWS info if applicable. The request body must include a valid migration ID and a list of cost resources. If AWS-specific details are provided, ensure all required fields are populated.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[Cost Management]"
+                ],
+                "summary": "Update Cost Information",
+                "operationId": "UpdateCostInfo",
+                "parameters": [
+                    {
+                        "description": "Request body containing cost update information",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/app.UpdateCostInfoReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully updated cost information",
+                        "schema": {
+                            "$ref": "#/definitions/app.AntResponse-cost_UpdateCostInfoResult"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request parameters",
+                        "schema": {
+                            "$ref": "#/definitions/app.AntResponse-string"
+                        }
+                    },
+                    "500": {
+                        "description": "Failed to update cost information",
+                        "schema": {
+                            "$ref": "#/definitions/app.AntResponse-string"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/load/generators": {
             "get": {
                 "description": "Retrieve a list of all installed load generators with pagination support.",
@@ -741,7 +897,7 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "tags": [
-                    "[Pricing Management]"
+                    "[Price Management]"
                 ],
                 "summary": "Get Price Information",
                 "operationId": "GetPriceInfo",
@@ -749,59 +905,59 @@ const docTemplate = `{
                     {
                         "type": "string",
                         "description": "Name of the region",
-                        "name": "RegionName",
+                        "name": "regionName",
                         "in": "query",
                         "required": true
                     },
                     {
                         "type": "string",
                         "description": "Name of the connection",
-                        "name": "ConnectionName",
+                        "name": "connectionName",
                         "in": "query",
                         "required": true
                     },
                     {
                         "type": "string",
                         "description": "Name of the cloud provider",
-                        "name": "ProviderName",
+                        "name": "providerName",
                         "in": "query",
                         "required": true
                     },
                     {
                         "type": "string",
                         "description": "Type of the instance",
-                        "name": "InstanceType",
+                        "name": "instanceType",
                         "in": "query",
                         "required": true
                     },
                     {
                         "type": "string",
                         "description": "Name of the zone",
-                        "name": "ZoneName",
+                        "name": "zoneName",
                         "in": "query"
                     },
                     {
                         "type": "string",
                         "description": "Number of virtual CPUs",
-                        "name": "VCpu",
+                        "name": "vCpu",
                         "in": "query"
                     },
                     {
                         "type": "string",
                         "description": "Amount of memory. Don't need to pass unit like 'gb'",
-                        "name": "Memory",
+                        "name": "memory",
                         "in": "query"
                     },
                     {
                         "type": "string",
                         "description": "Amount of storage",
-                        "name": "Storage",
+                        "name": "storage",
                         "in": "query"
                     },
                     {
                         "type": "string",
                         "description": "Operating system type",
-                        "name": "OsType",
+                        "name": "osType",
                         "in": "query"
                     }
                 ],
@@ -829,6 +985,26 @@ const docTemplate = `{
         }
     },
     "definitions": {
+        "app.AntResponse-array_cost_GetCostInfoResult": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "integer"
+                },
+                "errorMessage": {
+                    "type": "string"
+                },
+                "result": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/cost.GetCostInfoResult"
+                    }
+                },
+                "successMessage": {
+                    "type": "string"
+                }
+            }
+        },
         "app.AntResponse-array_load_LoadTestStatistics": {
             "type": "object",
             "properties": {
@@ -900,6 +1076,23 @@ const docTemplate = `{
                 },
                 "result": {
                     "$ref": "#/definitions/cost.AllPriceInfoResult"
+                },
+                "successMessage": {
+                    "type": "string"
+                }
+            }
+        },
+        "app.AntResponse-cost_UpdateCostInfoResult": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "integer"
+                },
+                "errorMessage": {
+                    "type": "string"
+                },
+                "result": {
+                    "$ref": "#/definitions/cost.UpdateCostInfoResult"
                 },
                 "successMessage": {
                     "type": "string"
@@ -1076,6 +1269,34 @@ const docTemplate = `{
                 }
             }
         },
+        "app.AwsAdditionalInfoReq": {
+            "type": "object",
+            "properties": {
+                "ownerId": {
+                    "type": "string"
+                },
+                "regions": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "app.CostResourceReq": {
+            "type": "object",
+            "properties": {
+                "resourceIds": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "resourceType": {
+                    "$ref": "#/definitions/constant.ResourceType"
+                }
+            }
+        },
         "app.InstallLoadGeneratorReq": {
             "type": "object",
             "properties": {
@@ -1179,6 +1400,30 @@ const docTemplate = `{
                 }
             }
         },
+        "app.UpdateCostInfoReq": {
+            "type": "object",
+            "required": [
+                "connectionName",
+                "costResources"
+            ],
+            "properties": {
+                "awsAdditionalInfo": {
+                    "$ref": "#/definitions/app.AwsAdditionalInfoReq"
+                },
+                "connectionName": {
+                    "type": "string"
+                },
+                "costResources": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/app.CostResourceReq"
+                    }
+                },
+                "migrationId": {
+                    "type": "string"
+                }
+            }
+        },
         "constant.ExecutionStatus": {
             "type": "string",
             "enum": [
@@ -1250,6 +1495,21 @@ const docTemplate = `{
                 "PerYear"
             ]
         },
+        "constant.ResourceType": {
+            "type": "string",
+            "enum": [
+                "VM",
+                "VNet",
+                "DataDisk",
+                "Etc"
+            ],
+            "x-enum-varnames": [
+                "VM",
+                "VNet",
+                "DataDisk",
+                "Etc"
+            ]
+        },
         "cost.AllPriceInfoResult": {
             "type": "object",
             "properties": {
@@ -1264,6 +1524,32 @@ const docTemplate = `{
                 },
                 "resultCount": {
                     "type": "integer"
+                }
+            }
+        },
+        "cost.GetCostInfoResult": {
+            "type": "object",
+            "properties": {
+                "category": {
+                    "type": "string"
+                },
+                "date": {
+                    "type": "string"
+                },
+                "provider": {
+                    "type": "string"
+                },
+                "resourceId": {
+                    "type": "string"
+                },
+                "resourceType": {
+                    "type": "string"
+                },
+                "totalCost": {
+                    "type": "number"
+                },
+                "unit": {
+                    "type": "string"
                 }
             }
         },
@@ -1323,6 +1609,20 @@ const docTemplate = `{
                 },
                 "zoneName": {
                     "type": "string"
+                }
+            }
+        },
+        "cost.UpdateCostInfoResult": {
+            "type": "object",
+            "properties": {
+                "fetchedDataCount": {
+                    "type": "integer"
+                },
+                "insertedDataCount": {
+                    "type": "integer"
+                },
+                "updatedDataCount": {
+                    "type": "integer"
                 }
             }
         },
@@ -1779,7 +2079,7 @@ const docTemplate = `{
 
 // SwaggerInfo holds exported Swagger Info so clients can modify it
 var SwaggerInfo = &swag.Spec{
-	Version:          "0.1",
+	Version:          "0.2.2",
 	Host:             "",
 	BasePath:         "/ant",
 	Schemes:          []string{},

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -4,10 +4,166 @@
         "description": "CM-ANT REST API swagger document.",
         "title": "CM-ANT REST API",
         "contact": {},
-        "version": "0.1"
+        "version": "0.2.2"
     },
     "basePath": "/ant",
     "paths": {
+        "/api/v1/cost/info": {
+            "get": {
+                "description": "Retrieve cost information for specified parameters within a defined date range. The date range must be within a 6-month period. Optionally, you can specify cost aggregation type and date order for the results.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[Cost Management]"
+                ],
+                "summary": "Get Cost Information",
+                "operationId": "GetCostInfo",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Start date for the cost information retrieval in 'YYYY-MM-DD' format",
+                        "name": "startDate",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "End date for the cost information retrieval in 'YYYY-MM-DD' format",
+                        "name": "endDate",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "csv",
+                        "description": "List of migration IDs to filter the cost information",
+                        "name": "migrationIds",
+                        "in": "query"
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "csv",
+                        "description": "List of cloud providers to filter the cost information",
+                        "name": "provider",
+                        "in": "query"
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "csv",
+                        "description": "List of resource types to filter the cost information",
+                        "name": "resourceTypes",
+                        "in": "query"
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "csv",
+                        "description": "List of resource IDs to filter the cost information",
+                        "name": "resourceIds",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Type of cost aggregation for the results (e.g., 'daily', 'weekly', 'monthly')",
+                        "name": "costAggregationType",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Order of dates in the result (e.g., 'asc', 'desc')",
+                        "name": "dateOrder",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Order of resource types in the result (e.g., 'asc', 'desc')",
+                        "name": "resourceTypeOrder",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully retrieved cost information",
+                        "schema": {
+                            "$ref": "#/definitions/app.AntResponse-array_cost_GetCostInfoResult"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request parameters",
+                        "schema": {
+                            "$ref": "#/definitions/app.AntResponse-string"
+                        }
+                    },
+                    "500": {
+                        "description": "Failed to retrieve cost information",
+                        "schema": {
+                            "$ref": "#/definitions/app.AntResponse-string"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Update cost information for specified resources, including details such as migration ID, cost resources, and additional AWS info if applicable. The request body must include a valid migration ID and a list of cost resources. If AWS-specific details are provided, ensure all required fields are populated.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[Cost Management]"
+                ],
+                "summary": "Update Cost Information",
+                "operationId": "UpdateCostInfo",
+                "parameters": [
+                    {
+                        "description": "Request body containing cost update information",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/app.UpdateCostInfoReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully updated cost information",
+                        "schema": {
+                            "$ref": "#/definitions/app.AntResponse-cost_UpdateCostInfoResult"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request parameters",
+                        "schema": {
+                            "$ref": "#/definitions/app.AntResponse-string"
+                        }
+                    },
+                    "500": {
+                        "description": "Failed to update cost information",
+                        "schema": {
+                            "$ref": "#/definitions/app.AntResponse-string"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/load/generators": {
             "get": {
                 "description": "Retrieve a list of all installed load generators with pagination support.",
@@ -733,7 +889,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "[Pricing Management]"
+                    "[Price Management]"
                 ],
                 "summary": "Get Price Information",
                 "operationId": "GetPriceInfo",
@@ -741,59 +897,59 @@
                     {
                         "type": "string",
                         "description": "Name of the region",
-                        "name": "RegionName",
+                        "name": "regionName",
                         "in": "query",
                         "required": true
                     },
                     {
                         "type": "string",
                         "description": "Name of the connection",
-                        "name": "ConnectionName",
+                        "name": "connectionName",
                         "in": "query",
                         "required": true
                     },
                     {
                         "type": "string",
                         "description": "Name of the cloud provider",
-                        "name": "ProviderName",
+                        "name": "providerName",
                         "in": "query",
                         "required": true
                     },
                     {
                         "type": "string",
                         "description": "Type of the instance",
-                        "name": "InstanceType",
+                        "name": "instanceType",
                         "in": "query",
                         "required": true
                     },
                     {
                         "type": "string",
                         "description": "Name of the zone",
-                        "name": "ZoneName",
+                        "name": "zoneName",
                         "in": "query"
                     },
                     {
                         "type": "string",
                         "description": "Number of virtual CPUs",
-                        "name": "VCpu",
+                        "name": "vCpu",
                         "in": "query"
                     },
                     {
                         "type": "string",
                         "description": "Amount of memory. Don't need to pass unit like 'gb'",
-                        "name": "Memory",
+                        "name": "memory",
                         "in": "query"
                     },
                     {
                         "type": "string",
                         "description": "Amount of storage",
-                        "name": "Storage",
+                        "name": "storage",
                         "in": "query"
                     },
                     {
                         "type": "string",
                         "description": "Operating system type",
-                        "name": "OsType",
+                        "name": "osType",
                         "in": "query"
                     }
                 ],
@@ -821,6 +977,26 @@
         }
     },
     "definitions": {
+        "app.AntResponse-array_cost_GetCostInfoResult": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "integer"
+                },
+                "errorMessage": {
+                    "type": "string"
+                },
+                "result": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/cost.GetCostInfoResult"
+                    }
+                },
+                "successMessage": {
+                    "type": "string"
+                }
+            }
+        },
         "app.AntResponse-array_load_LoadTestStatistics": {
             "type": "object",
             "properties": {
@@ -892,6 +1068,23 @@
                 },
                 "result": {
                     "$ref": "#/definitions/cost.AllPriceInfoResult"
+                },
+                "successMessage": {
+                    "type": "string"
+                }
+            }
+        },
+        "app.AntResponse-cost_UpdateCostInfoResult": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "integer"
+                },
+                "errorMessage": {
+                    "type": "string"
+                },
+                "result": {
+                    "$ref": "#/definitions/cost.UpdateCostInfoResult"
                 },
                 "successMessage": {
                     "type": "string"
@@ -1068,6 +1261,34 @@
                 }
             }
         },
+        "app.AwsAdditionalInfoReq": {
+            "type": "object",
+            "properties": {
+                "ownerId": {
+                    "type": "string"
+                },
+                "regions": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "app.CostResourceReq": {
+            "type": "object",
+            "properties": {
+                "resourceIds": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "resourceType": {
+                    "$ref": "#/definitions/constant.ResourceType"
+                }
+            }
+        },
         "app.InstallLoadGeneratorReq": {
             "type": "object",
             "properties": {
@@ -1171,6 +1392,30 @@
                 }
             }
         },
+        "app.UpdateCostInfoReq": {
+            "type": "object",
+            "required": [
+                "connectionName",
+                "costResources"
+            ],
+            "properties": {
+                "awsAdditionalInfo": {
+                    "$ref": "#/definitions/app.AwsAdditionalInfoReq"
+                },
+                "connectionName": {
+                    "type": "string"
+                },
+                "costResources": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/app.CostResourceReq"
+                    }
+                },
+                "migrationId": {
+                    "type": "string"
+                }
+            }
+        },
         "constant.ExecutionStatus": {
             "type": "string",
             "enum": [
@@ -1242,6 +1487,21 @@
                 "PerYear"
             ]
         },
+        "constant.ResourceType": {
+            "type": "string",
+            "enum": [
+                "VM",
+                "VNet",
+                "DataDisk",
+                "Etc"
+            ],
+            "x-enum-varnames": [
+                "VM",
+                "VNet",
+                "DataDisk",
+                "Etc"
+            ]
+        },
         "cost.AllPriceInfoResult": {
             "type": "object",
             "properties": {
@@ -1256,6 +1516,32 @@
                 },
                 "resultCount": {
                     "type": "integer"
+                }
+            }
+        },
+        "cost.GetCostInfoResult": {
+            "type": "object",
+            "properties": {
+                "category": {
+                    "type": "string"
+                },
+                "date": {
+                    "type": "string"
+                },
+                "provider": {
+                    "type": "string"
+                },
+                "resourceId": {
+                    "type": "string"
+                },
+                "resourceType": {
+                    "type": "string"
+                },
+                "totalCost": {
+                    "type": "number"
+                },
+                "unit": {
+                    "type": "string"
                 }
             }
         },
@@ -1315,6 +1601,20 @@
                 },
                 "zoneName": {
                     "type": "string"
+                }
+            }
+        },
+        "cost.UpdateCostInfoResult": {
+            "type": "object",
+            "properties": {
+                "fetchedDataCount": {
+                    "type": "integer"
+                },
+                "insertedDataCount": {
+                    "type": "integer"
+                },
+                "updatedDataCount": {
+                    "type": "integer"
                 }
             }
         },

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1,5 +1,18 @@
 basePath: /ant
 definitions:
+  app.AntResponse-array_cost_GetCostInfoResult:
+    properties:
+      code:
+        type: integer
+      errorMessage:
+        type: string
+      result:
+        items:
+          $ref: '#/definitions/cost.GetCostInfoResult'
+        type: array
+      successMessage:
+        type: string
+    type: object
   app.AntResponse-array_load_LoadTestStatistics:
     properties:
       code:
@@ -47,6 +60,17 @@ definitions:
         type: string
       result:
         $ref: '#/definitions/cost.AllPriceInfoResult'
+      successMessage:
+        type: string
+    type: object
+  app.AntResponse-cost_UpdateCostInfoResult:
+    properties:
+      code:
+        type: integer
+      errorMessage:
+        type: string
+      result:
+        $ref: '#/definitions/cost.UpdateCostInfoResult'
       successMessage:
         type: string
     type: object
@@ -160,6 +184,24 @@ definitions:
       successMessage:
         type: string
     type: object
+  app.AwsAdditionalInfoReq:
+    properties:
+      ownerId:
+        type: string
+      regions:
+        items:
+          type: string
+        type: array
+    type: object
+  app.CostResourceReq:
+    properties:
+      resourceIds:
+        items:
+          type: string
+        type: array
+      resourceType:
+        $ref: '#/definitions/constant.ResourceType'
+    type: object
   app.InstallLoadGeneratorReq:
     properties:
       installLocation:
@@ -227,6 +269,22 @@ definitions:
       loadTestKey:
         type: string
     type: object
+  app.UpdateCostInfoReq:
+    properties:
+      awsAdditionalInfo:
+        $ref: '#/definitions/app.AwsAdditionalInfoReq'
+      connectionName:
+        type: string
+      costResources:
+        items:
+          $ref: '#/definitions/app.CostResourceReq'
+        type: array
+      migrationId:
+        type: string
+    required:
+    - connectionName
+    - costResources
+    type: object
   constant.ExecutionStatus:
     enum:
     - on_preparing
@@ -283,6 +341,18 @@ definitions:
     x-enum-varnames:
     - PerHour
     - PerYear
+  constant.ResourceType:
+    enum:
+    - VM
+    - VNet
+    - DataDisk
+    - Etc
+    type: string
+    x-enum-varnames:
+    - VM
+    - VNet
+    - DataDisk
+    - Etc
   cost.AllPriceInfoResult:
     properties:
       infoSource:
@@ -293,6 +363,23 @@ definitions:
         type: array
       resultCount:
         type: integer
+    type: object
+  cost.GetCostInfoResult:
+    properties:
+      category:
+        type: string
+      date:
+        type: string
+      provider:
+        type: string
+      resourceId:
+        type: string
+      resourceType:
+        type: string
+      totalCost:
+        type: number
+      unit:
+        type: string
     type: object
   cost.PriceInfoResult:
     properties:
@@ -332,6 +419,15 @@ definitions:
         type: string
       zoneName:
         type: string
+    type: object
+  cost.UpdateCostInfoResult:
+    properties:
+      fetchedDataCount:
+        type: integer
+      insertedDataCount:
+        type: integer
+      updatedDataCount:
+        type: integer
     type: object
   load.GetAllLoadGeneratorInstallInfoResult:
     properties:
@@ -632,8 +728,121 @@ info:
   contact: {}
   description: CM-ANT REST API swagger document.
   title: CM-ANT REST API
-  version: "0.1"
+  version: 0.2.2
 paths:
+  /api/v1/cost/info:
+    get:
+      consumes:
+      - application/json
+      description: Retrieve cost information for specified parameters within a defined
+        date range. The date range must be within a 6-month period. Optionally, you
+        can specify cost aggregation type and date order for the results.
+      operationId: GetCostInfo
+      parameters:
+      - description: Start date for the cost information retrieval in 'YYYY-MM-DD'
+          format
+        in: query
+        name: startDate
+        required: true
+        type: string
+      - description: End date for the cost information retrieval in 'YYYY-MM-DD' format
+        in: query
+        name: endDate
+        required: true
+        type: string
+      - collectionFormat: csv
+        description: List of migration IDs to filter the cost information
+        in: query
+        items:
+          type: string
+        name: migrationIds
+        type: array
+      - collectionFormat: csv
+        description: List of cloud providers to filter the cost information
+        in: query
+        items:
+          type: string
+        name: provider
+        type: array
+      - collectionFormat: csv
+        description: List of resource types to filter the cost information
+        in: query
+        items:
+          type: string
+        name: resourceTypes
+        type: array
+      - collectionFormat: csv
+        description: List of resource IDs to filter the cost information
+        in: query
+        items:
+          type: string
+        name: resourceIds
+        type: array
+      - description: Type of cost aggregation for the results (e.g., 'daily', 'weekly',
+          'monthly')
+        in: query
+        name: costAggregationType
+        required: true
+        type: string
+      - description: Order of dates in the result (e.g., 'asc', 'desc')
+        in: query
+        name: dateOrder
+        type: string
+      - description: Order of resource types in the result (e.g., 'asc', 'desc')
+        in: query
+        name: resourceTypeOrder
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Successfully retrieved cost information
+          schema:
+            $ref: '#/definitions/app.AntResponse-array_cost_GetCostInfoResult'
+        "400":
+          description: Invalid request parameters
+          schema:
+            $ref: '#/definitions/app.AntResponse-string'
+        "500":
+          description: Failed to retrieve cost information
+          schema:
+            $ref: '#/definitions/app.AntResponse-string'
+      summary: Get Cost Information
+      tags:
+      - '[Cost Management]'
+    post:
+      consumes:
+      - application/json
+      description: Update cost information for specified resources, including details
+        such as migration ID, cost resources, and additional AWS info if applicable.
+        The request body must include a valid migration ID and a list of cost resources.
+        If AWS-specific details are provided, ensure all required fields are populated.
+      operationId: UpdateCostInfo
+      parameters:
+      - description: Request body containing cost update information
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/app.UpdateCostInfoReq'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Successfully updated cost information
+          schema:
+            $ref: '#/definitions/app.AntResponse-cost_UpdateCostInfoResult'
+        "400":
+          description: Invalid request parameters
+          schema:
+            $ref: '#/definitions/app.AntResponse-string'
+        "500":
+          description: Failed to update cost information
+          schema:
+            $ref: '#/definitions/app.AntResponse-string'
+      summary: Update Cost Information
+      tags:
+      - '[Cost Management]'
   /api/v1/load/generators:
     get:
       consumes:
@@ -1121,43 +1330,43 @@ paths:
       parameters:
       - description: Name of the region
         in: query
-        name: RegionName
+        name: regionName
         required: true
         type: string
       - description: Name of the connection
         in: query
-        name: ConnectionName
+        name: connectionName
         required: true
         type: string
       - description: Name of the cloud provider
         in: query
-        name: ProviderName
+        name: providerName
         required: true
         type: string
       - description: Type of the instance
         in: query
-        name: InstanceType
+        name: instanceType
         required: true
         type: string
       - description: Name of the zone
         in: query
-        name: ZoneName
+        name: zoneName
         type: string
       - description: Number of virtual CPUs
         in: query
-        name: VCpu
+        name: vCpu
         type: string
       - description: Amount of memory. Don't need to pass unit like 'gb'
         in: query
-        name: Memory
+        name: memory
         type: string
       - description: Amount of storage
         in: query
-        name: Storage
+        name: storage
         type: string
       - description: Operating system type
         in: query
-        name: OsType
+        name: osType
         type: string
       produces:
       - application/json
@@ -1176,5 +1385,5 @@ paths:
             $ref: '#/definitions/app.AntResponse-string'
       summary: Get Price Information
       tags:
-      - '[Pricing Management]'
+      - '[Price Management]'
 swagger: "2.0"

--- a/cmd/cm-ant/main.go
+++ b/cmd/cm-ant/main.go
@@ -14,9 +14,8 @@ import (
 // InitRouter initializes the routing for CM-ANT API server.
 
 // @title CM-ANT REST API
-// @version 0.1
+// @version 0.2.2
 // @description CM-ANT REST API swagger document.
-
 // @basePath /ant
 func main() {
 

--- a/go.mod
+++ b/go.mod
@@ -3,15 +3,18 @@ module github.com/cloud-barista/cm-ant
 go 1.21.6
 
 require (
+	github.com/aws/aws-sdk-go v1.55.5
 	github.com/google/uuid v1.6.0
 	github.com/labstack/echo/v4 v4.12.0
 	github.com/melbahja/goph v1.4.0
+	github.com/pkg/sftp v1.13.6
 	github.com/rs/zerolog v1.32.0
 	github.com/spf13/viper v1.18.2
 	github.com/stretchr/testify v1.9.0
 	github.com/swaggo/echo-swagger v1.4.1
 	github.com/swaggo/swag v1.16.3
 	golang.org/x/crypto v0.25.0
+	gorm.io/driver/postgres v1.5.9
 	gorm.io/driver/sqlite v1.5.5
 	gorm.io/gorm v1.25.11
 )
@@ -33,10 +36,10 @@ require (
 	github.com/jackc/puddle/v2 v2.2.1 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/kr/fs v0.1.0 // indirect
 	github.com/labstack/gommon v0.4.2 // indirect
-	github.com/lib/pq v1.10.9 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
@@ -45,7 +48,6 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.1.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/pkg/sftp v1.13.6 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/sagikazarmark/locafero v0.4.0 // indirect
 	github.com/sagikazarmark/slog-shim v0.1.0 // indirect
@@ -69,5 +71,4 @@ require (
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	gorm.io/driver/postgres v1.5.9 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc=
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
+github.com/aws/aws-sdk-go v1.55.5 h1:KKUZBfBoyqy5d3swXyiC7Q76ic40rYcbqH7qjh59kzU=
+github.com/aws/aws-sdk-go v1.55.5/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -40,6 +42,10 @@ github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
 github.com/jinzhu/now v1.1.5 h1:/o9tlHleP7gOFmsnYNz3RGnqzefHA47wQpKrrdTIwXQ=
 github.com/jinzhu/now v1.1.5/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
+github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
+github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/kr/fs v0.1.0 h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8=
@@ -52,8 +58,6 @@ github.com/labstack/echo/v4 v4.12.0 h1:IKpw49IMryVB2p1a4dzwlhP1O2Tf2E0Ir/450lH+k
 github.com/labstack/echo/v4 v4.12.0/go.mod h1:UP9Cr2DJXbOK3Kr9ONYzNowSh7HP0aG0ShAyycHSJvM=
 github.com/labstack/gommon v0.4.2 h1:F8qTUNXgG1+6WQmqoUWnz8WiEU60mXVVw0P4ht1WRA0=
 github.com/labstack/gommon v0.4.2/go.mod h1:QlUFxVM+SNXhDL/Z7YhocGIBYOiwB0mXm1+1bAPHPyU=
-github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
-github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0VQdvPDY=
 github.com/magiconair/properties v1.8.7/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
@@ -191,6 +195,7 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntN
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/ini.v1 v1.67.0 h1:Dgnx+6+nfE+IfzjUEISNeydPJh9AXNNsWbGP9KzCsOA=
 gopkg.in/ini.v1 v1.67.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
+gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
@@ -200,7 +205,5 @@ gorm.io/driver/postgres v1.5.9 h1:DkegyItji119OlcaLjqN11kHoUgZ/j13E0jkJZgD6A8=
 gorm.io/driver/postgres v1.5.9/go.mod h1:DX3GReXH+3FPWGrrgffdvCk3DQ1dwDPdmbenSkweRGI=
 gorm.io/driver/sqlite v1.5.5 h1:7MDMtUZhV065SilG62E0MquljeArQZNfJnjd9i9gx3E=
 gorm.io/driver/sqlite v1.5.5/go.mod h1:6NgQ7sQWAIFsPrJJl1lSNSu2TABh0ZZ/zm5fosATavE=
-gorm.io/gorm v1.25.8 h1:WAGEZ/aEcznN4D03laj8DKnehe1e9gYQAjW8xyPRdeo=
-gorm.io/gorm v1.25.8/go.mod h1:hbnx/Oo0ChWMn1BIhpy1oYozzpM15i4YPuHDmfYtwg8=
 gorm.io/gorm v1.25.11 h1:/Wfyg1B/je1hnDx3sMkX+gAlxrlZpn6X0BXRlwXlvHg=
 gorm.io/gorm v1.25.11/go.mod h1:xh7N7RHfYlNc5EmcI/El95gXusucDrQnHXe0+CgWcLQ=

--- a/internal/app/cost_handler.go
+++ b/internal/app/cost_handler.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/cloud-barista/cm-ant/internal/core/cost"
-	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 )
 
@@ -78,22 +77,6 @@ func (server *AntServer) updateCostInfo(c echo.Context) error {
 	if len(req.CostResources) == 0 {
 		return errorResponseJson(http.StatusBadRequest, "Migrated resource id list should pass")
 	}
-
-	startDate, err := time.Parse("2006-01-02", req.StartDate)
-	if err != nil {
-		return errorResponseJson(http.StatusBadRequest, "Invalid startDate format")
-	}
-
-	endDate, err := time.Parse("2006-01-02", req.EndDate)
-	if err != nil {
-		return errorResponseJson(http.StatusBadRequest, "Invalid endDate format")
-	}
-
-	duration := endDate.Sub(startDate)
-	if duration.Hours() > 14*24 {
-		return errorResponseJson(http.StatusBadRequest, "The date range cannot exceed 14 days")
-	}
-
 	costResources := make([]cost.CostResourceParam, 0)
 
 	for _, v := range req.CostResources {
@@ -103,8 +86,11 @@ func (server *AntServer) updateCostInfo(c echo.Context) error {
 		})
 	}
 
+
+	endDate := time.Now().Truncate(24*time.Hour).AddDate(0, 0, 1)
+	startDate := endDate.AddDate(0, 0, -14)
 	param := cost.UpdateCostInfoParam{
-		MigrationId:    uuid.New().String(),
+		MigrationId:    req.MigrationId,
 		Provider:       "aws",
 		ConnectionName: req.ConnectionName,
 		StartDate:      startDate,

--- a/internal/app/cost_handler.go
+++ b/internal/app/cost_handler.go
@@ -10,22 +10,21 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-// getPriceInfo handler function that retrieves pricing information for cloud resources.
 // @Id GetPriceInfo
 // @Summary Get Price Information
 // @Description Retrieve pricing information for cloud resources based on specified parameters.
-// @Tags [Pricing Management]
+// @Tags [Price Management]
 // @Accept json
 // @Produce json
-// @Param RegionName query string true "Name of the region"
-// @Param ConnectionName query string true "Name of the connection"
-// @Param ProviderName query string true "Name of the cloud provider"
-// @Param InstanceType query string true "Type of the instance"
-// @Param ZoneName query string false "Name of the zone"
-// @Param VCpu query string false "Number of virtual CPUs"
-// @Param Memory query string false "Amount of memory. Don't need to pass unit like 'gb'"
-// @Param Storage query string false "Amount of storage"
-// @Param OsType query string false "Operating system type"
+// @Param regionName query string true "Name of the region"
+// @Param connectionName query string true "Name of the connection"
+// @Param providerName query string true "Name of the cloud provider"
+// @Param instanceType query string true "Type of the instance"
+// @Param zoneName query string false "Name of the zone"
+// @Param vCpu query string false "Number of virtual CPUs"
+// @Param memory query string false "Amount of memory. Don't need to pass unit like 'gb'"
+// @Param storage query string false "Amount of storage"
+// @Param osType query string false "Operating system type"
 // @Success 200 {object} app.AntResponse[cost.AllPriceInfoResult] "Successfully retrieved pricing information"
 // @Failure 400 {object} app.AntResponse[string] "Invalid request parameters"
 // @Failure 500 {object} app.AntResponse[string] "Failed to retrieve pricing information"
@@ -68,6 +67,17 @@ func (server *AntServer) getPriceInfo(c echo.Context) error {
 	)
 }
 
+// @Id UpdateCostInfo
+// @Summary Update Cost Information
+// @Description Update cost information for specified resources, including details such as migration ID, cost resources, and additional AWS info if applicable. The request body must include a valid migration ID and a list of cost resources. If AWS-specific details are provided, ensure all required fields are populated.
+// @Tags [Cost Management]
+// @Accept json
+// @Produce json
+// @Param body body app.UpdateCostInfoReq true "Request body containing cost update information"
+// @Success 200 {object} app.AntResponse[cost.UpdateCostInfoResult] "Successfully updated cost information"
+// @Failure 400 {object} app.AntResponse[string] "Invalid request parameters"
+// @Failure 500 {object} app.AntResponse[string] "Failed to update cost information"
+// @Router /api/v1/cost/info [post]
 func (server *AntServer) updateCostInfo(c echo.Context) error {
 	var req UpdateCostInfoReq
 
@@ -115,11 +125,30 @@ func (server *AntServer) updateCostInfo(c echo.Context) error {
 
 	return successResponseJson(
 		c,
-		"Successfully get cost info.",
+		"Successfully updated cost info.",
 		r,
 	)
 }
 
+// @Id GetCostInfo
+// @Summary Get Cost Information
+// @Description Retrieve cost information for specified parameters within a defined date range. The date range must be within a 6-month period. Optionally, you can specify cost aggregation type and date order for the results.
+// @Tags [Cost Management]
+// @Accept json
+// @Produce json
+// @Param startDate query string true "Start date for the cost information retrieval in 'YYYY-MM-DD' format"
+// @Param endDate query string true "End date for the cost information retrieval in 'YYYY-MM-DD' format"
+// @Param migrationIds query []string false "List of migration IDs to filter the cost information"
+// @Param provider query []string false "List of cloud providers to filter the cost information"
+// @Param resourceTypes query []string false "List of resource types to filter the cost information"
+// @Param resourceIds query []string false "List of resource IDs to filter the cost information"
+// @Param costAggregationType query string true "Type of cost aggregation for the results (e.g., 'daily', 'weekly', 'monthly')"
+// @Param dateOrder query string false "Order of dates in the result (e.g., 'asc', 'desc')"
+// @Param resourceTypeOrder query string false "Order of resource types in the result (e.g., 'asc', 'desc')"
+// @Success 200 {object} app.AntResponse[[]cost.GetCostInfoResult] "Successfully retrieved cost information"
+// @Failure 400 {object} app.AntResponse[string] "Invalid request parameters"
+// @Failure 500 {object} app.AntResponse[string] "Failed to retrieve cost information"
+// @Router /api/v1/cost/info [get]
 func (s *AntServer) getCostInfo(c echo.Context) error {
 	var req GetCostInfoReq
 	if err := c.Bind(&req); err != nil {

--- a/internal/app/cost_req.go
+++ b/internal/app/cost_req.go
@@ -18,8 +18,6 @@ type GetPriceInfoReq struct {
 type UpdateCostInfo struct {
 	MigrationId       string            `json:"migrationId"`
 	ConnectionName    string            `json:"connectionName"`
-	StartDate         string            `json:"startDate" validate:"require"`
-	EndDate           string            `json:"endDate" validate:"require"`
 	CostResources     []CostResource    `json:"costResources" validate:"require"`
 	AwsAdditionalInfo AwsAdditionalInfo `json:"awsAdditionalInfo"`
 }

--- a/internal/app/cost_req.go
+++ b/internal/app/cost_req.go
@@ -3,10 +3,10 @@ package app
 import "github.com/cloud-barista/cm-ant/internal/core/common/constant"
 
 type GetPriceInfoReq struct {
-	ProviderName   string `json:"providerName" validate:"require"`
-	ConnectionName string `json:"connectionName" validate:"require"`
-	RegionName     string `json:"regionName" validate:"require"`
-	InstanceType   string `json:"instanceType" validate:"require"`
+	ProviderName   string `json:"providerName" validate:"required"`
+	ConnectionName string `json:"connectionName" validate:"required"`
+	RegionName     string `json:"regionName" validate:"required"`
+	InstanceType   string `json:"instanceType" validate:"required"`
 
 	ZoneName string `json:"zoneName,omitempty"`
 	VCpu     string `json:"vCpu,omitempty"`
@@ -15,19 +15,31 @@ type GetPriceInfoReq struct {
 	OsType   string `json:"osType,omitempty"`
 }
 
-type UpdateCostInfo struct {
-	MigrationId       string            `json:"migrationId"`
-	ConnectionName    string            `json:"connectionName"`
-	CostResources     []CostResource    `json:"costResources" validate:"require"`
-	AwsAdditionalInfo AwsAdditionalInfo `json:"awsAdditionalInfo"`
+type UpdateCostInfoReq struct {
+	MigrationId       string               `json:"migrationId"`
+	ConnectionName    string               `json:"connectionName"`
+	CostResources     []CostResourceReq    `json:"costResources" validate:"required"`
+	AwsAdditionalInfo AwsAdditionalInfoReq `json:"awsAdditionalInfo"`
 }
 
-type CostResource struct {
+type CostResourceReq struct {
 	ResourceType constant.ResourceType `json:"resourceType"`
 	ResourceIds  []string              `json:"resourceIds"`
 }
 
-type AwsAdditionalInfo struct {
+type AwsAdditionalInfoReq struct {
 	OwnerId string   `json:"ownerId"`
 	Regions []string `json:"regions"`
+}
+
+type GetCostInfoReq struct {
+	StartDate           string                       `query:"startDate" validate:"required"`
+	EndDate             string                       `query:"endDate" validate:"required"`
+	MigrationIds        []string                     `query:"migrationIds"`
+	Providers           []string                     `query:"provider"`
+	ResourceTypes       []constant.ResourceType      `query:"resourceTypes"`
+	ResourceIds         []string                     `query:"resourceIds"`
+	CostAggregationType constant.CostAggregationType `query:"costAggregationType" validate:"required"`
+	DateOrder           constant.OrderType           `query:"dateOrder"`
+	ResourceTypeOrder   constant.OrderType           `query:"resourceTypeOrder"`
 }

--- a/internal/app/cost_req.go
+++ b/internal/app/cost_req.go
@@ -1,6 +1,8 @@
 package app
 
-type PriceInfoReq struct {
+import "github.com/cloud-barista/cm-ant/internal/core/common/constant"
+
+type GetPriceInfoReq struct {
 	ProviderName   string `json:"providerName" validate:"require"`
 	ConnectionName string `json:"connectionName" validate:"require"`
 	RegionName     string `json:"regionName" validate:"require"`
@@ -11,4 +13,23 @@ type PriceInfoReq struct {
 	Memory   string `json:"memory,omitempty"`
 	Storage  string `json:"storage,omitempty"`
 	OsType   string `json:"osType,omitempty"`
+}
+
+type UpdateCostInfo struct {
+	MigrationId       string            `json:"migrationId"`
+	ConnectionName    string            `json:"connectionName"`
+	StartDate         string            `json:"startDate" validate:"require"`
+	EndDate           string            `json:"endDate" validate:"require"`
+	CostResources     []CostResource    `json:"costResources" validate:"require"`
+	AwsAdditionalInfo AwsAdditionalInfo `json:"awsAdditionalInfo"`
+}
+
+type CostResource struct {
+	ResourceType constant.ResourceType `json:"resourceType"`
+	ResourceIds  []string              `json:"resourceIds"`
+}
+
+type AwsAdditionalInfo struct {
+	OwnerId string   `json:"ownerId"`
+	Regions []string `json:"regions"`
 }

--- a/internal/app/cost_req.go
+++ b/internal/app/cost_req.go
@@ -3,21 +3,21 @@ package app
 import "github.com/cloud-barista/cm-ant/internal/core/common/constant"
 
 type GetPriceInfoReq struct {
-	ProviderName   string `json:"providerName" validate:"required"`
-	ConnectionName string `json:"connectionName" validate:"required"`
-	RegionName     string `json:"regionName" validate:"required"`
-	InstanceType   string `json:"instanceType" validate:"required"`
+	ProviderName   string `query:"providerName" validate:"required"`
+	ConnectionName string `query:"connectionName" validate:"required"`
+	RegionName     string `query:"regionName" validate:"required"`
+	InstanceType   string `query:"instanceType" validate:"required"`
 
-	ZoneName string `json:"zoneName,omitempty"`
-	VCpu     string `json:"vCpu,omitempty"`
-	Memory   string `json:"memory,omitempty"`
-	Storage  string `json:"storage,omitempty"`
-	OsType   string `json:"osType,omitempty"`
+	ZoneName string `query:"zoneName,omitempty"`
+	VCpu     string `query:"vCpu,omitempty"`
+	Memory   string `query:"memory,omitempty"`
+	Storage  string `query:"storage,omitempty"`
+	OsType   string `query:"osType,omitempty"`
 }
 
 type UpdateCostInfoReq struct {
 	MigrationId       string               `json:"migrationId"`
-	ConnectionName    string               `json:"connectionName"`
+	ConnectionName    string               `json:"connectionName" validate:"required"`
 	CostResources     []CostResourceReq    `json:"costResources" validate:"required"`
 	AwsAdditionalInfo AwsAdditionalInfoReq `json:"awsAdditionalInfo"`
 }

--- a/internal/app/load_handler.go
+++ b/internal/app/load_handler.go
@@ -283,8 +283,6 @@ func (s *AntServer) stopLoadTest(c echo.Context) error {
 // @Failure 500 {object} app.AntResponse[string] "Failed to retrieve load test result"
 // @Router /api/v1/load/test/result [get]
 func (s *AntServer) getLoadTestResult(c echo.Context) error {
-	// @Success 200 {object} app.AntResponse[{[normal]=map[string][]resultRawData,[aggregate]=[]load.LoadTestStatistics}] "Successfully retrieved load test metrics"
-
 	var req GetLoadTestResultReq
 	if err := c.Bind(&req); err != nil {
 		return errorResponseJson(http.StatusBadRequest, "Invalid request parameters")

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -72,7 +72,7 @@ func (server *AntServer) InitRouter() error {
 	{
 		priceRouter := versionRouter.Group("/price")
 		{
-			priceRouter.POST("/info", server.getPriceInfo)
+			priceRouter.GET("/info", server.getPriceInfo)
 		}
 
 		costRouter := versionRouter.Group("/cost")

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -70,9 +70,14 @@ func (server *AntServer) InitRouter() error {
 	}
 
 	{
-		priceRouter := versionRouter.Group("/price/info")
+		priceRouter := versionRouter.Group("/price")
 		{
-			priceRouter.POST("", server.getPriceInfo)
+			priceRouter.POST("/info", server.getPriceInfo)
+		}
+
+		costRouter := versionRouter.Group("/cost")
+		{
+			costRouter.POST("/info", server.updateCostInfo)
 		}
 	}
 

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -78,6 +78,7 @@ func (server *AntServer) InitRouter() error {
 		costRouter := versionRouter.Group("/cost")
 		{
 			costRouter.POST("/info", server.updateCostInfo)
+			costRouter.GET("/info", server.getCostInfo)
 		}
 	}
 

--- a/internal/app/server.go
+++ b/internal/app/server.go
@@ -89,7 +89,9 @@ func initializeRepositories(conn *gorm.DB) *antRepositories {
 // initializeServices initializes the services with the given repositories and various client.
 func initializeServices(repos *antRepositories, tbClient *tumblebug.TumblebugClient, sClient *spider.SpiderClient) *antServices {
 	loadServ := load.NewLoadService(repos.loadRepo, tbClient)
-	costServ := cost.NewCostService(repos.costRepo, sClient)
+
+	cc := cost.NewAwsCostExplorerSpiderCostCollector(sClient)
+	costServ := cost.NewCostService(repos.costRepo, sClient, cc)
 
 	return &antServices{
 		loadService: loadServ,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -66,13 +66,13 @@ func InitConfig() error {
 
 	err := viper.ReadInConfig()
 	if err != nil {
-		utils.LogErrorf("[ERROR] Fatal error while reading config file: %v", err)
+		utils.LogErrorf("Fatal error while reading config file: %v", err)
 		return fmt.Errorf("fatal error while read config file: %w", err)
 	}
 
 	err = viper.Unmarshal(&cfg)
 	if err != nil {
-		utils.LogErrorf("[ERROR] Fatal error while unmarshaling config: %v", err)
+		utils.LogErrorf("Fatal error while unmarshaling config: %v", err)
 		return fmt.Errorf("fatal error while unmarshal from config to ant config: %w", err)
 	}
 

--- a/internal/core/common/constant/constant.go
+++ b/internal/core/common/constant/constant.go
@@ -63,3 +63,53 @@ type MemoryUnit string
 const (
 	GIB MemoryUnit = "GiB"
 )
+
+type ResourceType string
+
+const (
+	VM       ResourceType = "VM"
+	VNet     ResourceType = "VNet"
+	DataDisk ResourceType = "DataDisk"
+	Etc      ResourceType = "Etc"
+
+	NLB           ResourceType = "NLB"
+	Namespace     ResourceType = "Namespace"
+	VMImage       ResourceType = "VMImage"
+	SecurityGroup ResourceType = "SecurityGroup"
+	KeyPair       ResourceType = "KeyPair"
+	Database      ResourceType = "Database"
+	Application   ResourceType = "Application"
+	WebServe      ResourceType = "Web Serve"
+)
+
+type AwsService string
+
+const (
+	// arn:aws:ec2:ap-northeast-1:050864702683:network-interface/eni-04c34238a6db01e9b
+	AwsVpc          AwsService = "Amazon Virtual Private Cloud"           // arn:aws:ec2:<regionId>:<ownerId>:network-interface/eni-07dd0cea3916a5c99, arn:aws:ec2:<regionId>:<ownerId>:elastic-ip/eipalloc-0429227700117b866
+	AwsEC2          AwsService = "Amazon Elastic Compute Cloud - Compute" // i-005d85400a201b7f3
+	AwsEC2Other     AwsService = "EC2 - Other"                            // i-005d85400a201b7f3, vol-0033c8dcc5aeb70c9
+	AwsCostExplorer AwsService = "AWS Cost Explorer"                      // NoResourceId
+	AwsTax          AwsService = "Tax"                                    // NoResourceId
+
+	AwsGlue            AwsService = "AWS Glue"
+	AwsKMS             AwsService = "AWS Key Management Service"
+	AwsLambda          AwsService = "AWS Lambda"
+	AwsMigrationHub    AwsService = "AWS Migration Hub Refactor Spaces"
+	AwsSecretManager   AwsService = "AWS Secrets Manager"
+	AwsStepFunction    AwsService = "AWS Step Functions"
+	AwsSystemManager   AwsService = "AWS Systems Manager"
+	AwsApiGateway      AwsService = "Amazon API Gateway"
+	AwsECR             AwsService = "Amazon EC2 Container Registry (ECR)"
+	AwsEKS             AwsService = "Amazon Elastic Container Service for Kubernetes"
+	AwsELB             AwsService = "Amazon Elastic Load Balancing"
+	AwsLightsail       AwsService = "Amazon Lightsail"
+	AwsLocationService AwsService = "Amazon Location Service"
+	AwsRegistrar       AwsService = "Amazon Registrar"
+	AwsRDS             AwsService = "Amazon Relational Database Service"
+	AwsRoute53         AwsService = "Amazon Route 53"
+	AwsSNS             AwsService = "Amazon Simple Notification Service"
+	AwsSQS             AwsService = "Amazon Simple Queue Service"
+	AwsS3              AwsService = "Amazon Simple Storage Service"
+	AwsCloudWatch      AwsService = "AmazonCloudWatch"
+)

--- a/internal/core/common/constant/constant.go
+++ b/internal/core/common/constant/constant.go
@@ -113,3 +113,18 @@ const (
 	// AwsS3              AwsService = "Amazon Simple Storage Service"
 	// AwsCloudWatch      AwsService = "AmazonCloudWatch"
 )
+
+type CostAggregationType string
+
+const (
+	Daily   CostAggregationType = "daily"
+	Weekly  CostAggregationType = "weekly"
+	Monthly CostAggregationType = "monthly"
+)
+
+type OrderType string
+
+const (
+	Asc  OrderType = "asc"
+	Desc OrderType = "desc"
+)

--- a/internal/core/common/constant/constant.go
+++ b/internal/core/common/constant/constant.go
@@ -72,44 +72,44 @@ const (
 	DataDisk ResourceType = "DataDisk"
 	Etc      ResourceType = "Etc"
 
-	NLB           ResourceType = "NLB"
-	Namespace     ResourceType = "Namespace"
-	VMImage       ResourceType = "VMImage"
-	SecurityGroup ResourceType = "SecurityGroup"
-	KeyPair       ResourceType = "KeyPair"
-	Database      ResourceType = "Database"
-	Application   ResourceType = "Application"
-	WebServe      ResourceType = "Web Serve"
+	// NLB           ResourceType = "NLB"
+	// Namespace     ResourceType = "Namespace"
+	// VMImage       ResourceType = "VMImage"
+	// SecurityGroup ResourceType = "SecurityGroup"
+	// KeyPair       ResourceType = "KeyPair"
+	// Database      ResourceType = "Database"
+	// Application   ResourceType = "Application"
+	// WebServe      ResourceType = "Web Serve"
 )
 
 type AwsService string
 
 const (
-	// arn:aws:ec2:ap-northeast-1:050864702683:network-interface/eni-04c34238a6db01e9b
-	AwsVpc          AwsService = "Amazon Virtual Private Cloud"           // arn:aws:ec2:<regionId>:<ownerId>:network-interface/eni-07dd0cea3916a5c99, arn:aws:ec2:<regionId>:<ownerId>:elastic-ip/eipalloc-0429227700117b866
-	AwsEC2          AwsService = "Amazon Elastic Compute Cloud - Compute" // i-005d85400a201b7f3
-	AwsEC2Other     AwsService = "EC2 - Other"                            // i-005d85400a201b7f3, vol-0033c8dcc5aeb70c9
+	// arn:aws:ec2:<regionId>:<ownerId>:network-interface/eni-xxxxxx, arn:aws:ec2:<regionId>:<ownerId>:elastic-ip/eipalloc-xxxxx
+	AwsVpc          AwsService = "Amazon Virtual Private Cloud"
+	AwsEC2          AwsService = "Amazon Elastic Compute Cloud - Compute" // i-xxxxx
+	AwsEC2Other     AwsService = "EC2 - Other"                            // i-xxxxxx, vol-xxxxxx
 	AwsCostExplorer AwsService = "AWS Cost Explorer"                      // NoResourceId
 	AwsTax          AwsService = "Tax"                                    // NoResourceId
 
-	AwsGlue            AwsService = "AWS Glue"
-	AwsKMS             AwsService = "AWS Key Management Service"
-	AwsLambda          AwsService = "AWS Lambda"
-	AwsMigrationHub    AwsService = "AWS Migration Hub Refactor Spaces"
-	AwsSecretManager   AwsService = "AWS Secrets Manager"
-	AwsStepFunction    AwsService = "AWS Step Functions"
-	AwsSystemManager   AwsService = "AWS Systems Manager"
-	AwsApiGateway      AwsService = "Amazon API Gateway"
-	AwsECR             AwsService = "Amazon EC2 Container Registry (ECR)"
-	AwsEKS             AwsService = "Amazon Elastic Container Service for Kubernetes"
-	AwsELB             AwsService = "Amazon Elastic Load Balancing"
-	AwsLightsail       AwsService = "Amazon Lightsail"
-	AwsLocationService AwsService = "Amazon Location Service"
-	AwsRegistrar       AwsService = "Amazon Registrar"
-	AwsRDS             AwsService = "Amazon Relational Database Service"
-	AwsRoute53         AwsService = "Amazon Route 53"
-	AwsSNS             AwsService = "Amazon Simple Notification Service"
-	AwsSQS             AwsService = "Amazon Simple Queue Service"
-	AwsS3              AwsService = "Amazon Simple Storage Service"
-	AwsCloudWatch      AwsService = "AmazonCloudWatch"
+	// AwsGlue            AwsService = "AWS Glue"
+	// AwsKMS             AwsService = "AWS Key Management Service"
+	// AwsLambda          AwsService = "AWS Lambda"
+	// AwsMigrationHub    AwsService = "AWS Migration Hub Refactor Spaces"
+	// AwsSecretManager   AwsService = "AWS Secrets Manager"
+	// AwsStepFunction    AwsService = "AWS Step Functions"
+	// AwsSystemManager   AwsService = "AWS Systems Manager"
+	// AwsApiGateway      AwsService = "Amazon API Gateway"
+	// AwsECR             AwsService = "Amazon EC2 Container Registry (ECR)"
+	// AwsEKS             AwsService = "Amazon Elastic Container Service for Kubernetes"
+	// AwsELB             AwsService = "Amazon Elastic Load Balancing"
+	// AwsLightsail       AwsService = "Amazon Lightsail"
+	// AwsLocationService AwsService = "Amazon Location Service"
+	// AwsRegistrar       AwsService = "Amazon Registrar"
+	// AwsRDS             AwsService = "Amazon Relational Database Service"
+	// AwsRoute53         AwsService = "Amazon Route 53"
+	// AwsSNS             AwsService = "Amazon Simple Notification Service"
+	// AwsSQS             AwsService = "Amazon Simple Queue Service"
+	// AwsS3              AwsService = "Amazon Simple Storage Service"
+	// AwsCloudWatch      AwsService = "AmazonCloudWatch"
 )

--- a/internal/core/cost/cost_collector.go
+++ b/internal/core/cost/cost_collector.go
@@ -1,0 +1,288 @@
+package cost
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/cloud-barista/cm-ant/internal/core/common/constant"
+	"github.com/cloud-barista/cm-ant/internal/infra/outbound/spider"
+	"github.com/cloud-barista/cm-ant/internal/utils"
+)
+
+type CostCollector interface {
+	GetCostInfo(context.Context, UpdateCostInfoParam) (CostInfos, error)
+}
+
+type AwsCostExplorerSpiderCostCollector struct {
+	sc *spider.SpiderClient
+}
+
+func NewAwsCostExplorerSpiderCostCollector(sc *spider.SpiderClient) CostCollector {
+	return &AwsCostExplorerSpiderCostCollector{
+		sc: sc,
+	}
+}
+
+var (
+	resourceFilterMap = map[constant.ResourceType][]constant.AwsService{
+		constant.VM: {
+			constant.AwsEC2,
+			constant.AwsEC2Other,
+		},
+		constant.VNet: {
+			constant.AwsVpc,
+		},
+		constant.DataDisk: {
+			constant.AwsEC2Other,
+		},
+	}
+	serviceToResourceType = map[constant.AwsService]constant.ResourceType{
+		constant.AwsEC2:          constant.VM,
+		constant.AwsEC2Other:     constant.VM,
+		constant.AwsVpc:          constant.VNet,
+		constant.AwsCostExplorer: constant.Etc,
+		constant.AwsTax:          constant.Etc,
+	}
+)
+
+type costWithResourceReq struct {
+	StartDate   string           `json:"startDate"`
+	EndDate     string           `json:"endDate"`
+	Granularity string           `json:"granularity"` // HOURLY, DAILY, MONTHLY
+	Metrics     []string         `json:"metrics"`
+	Filter      filterExpression `json:"filter"`
+	Groups      []groupBy        `json:"groups"`
+}
+
+type filterExpression struct {
+	And            []*filterExpression `json:"and,omitempty"`
+	Or             []*filterExpression `json:"or,omitempty"`
+	Not            *filterExpression   `json:"not,omitempty"`
+	CostCategories *keyValues          `json:"costCategories,omitempty"`
+	Dimensions     *keyValues          `json:"dimensions,omitempty"`
+	Tags           *keyValues          `json:"tags,omitempty"`
+}
+
+type keyValues struct {
+	Key    string   `json:"key"`
+	Values []string `json:"values"`
+}
+
+type groupBy struct {
+	Key  string `json:"key"`
+	Type string `json:"type"` // DIMENSION | TAG | COST_CATEGORY
+}
+
+func (a *AwsCostExplorerSpiderCostCollector) generateFilterValue(
+	costResources []CostResourceParam, awsAdditionalInfo AwsAdditionalInfoParam,
+) (
+	[]string, []string, error,
+) {
+	var serviceValue = make([]string, 0)
+	var resourceIdValues = make([]string, 0)
+
+	for _, cr := range costResources {
+		resources, ok := resourceFilterMap[cr.ResourceType]
+		if !ok {
+			continue
+		}
+
+		for _, n := range resources {
+			serviceValue = append(serviceValue, string(n))
+		}
+
+		if cr.ResourceType == constant.VNet {
+			var idsTmp = make([]string, 0)
+			for _, r := range awsAdditionalInfo.Regions {
+				for _, id := range cr.ResourceIds {
+					resourceId := fmt.Sprintf("arn:aws:ec2:%s:%s:network-interface/%s", r, awsAdditionalInfo.OwnerId, id)
+					idsTmp = append(idsTmp, resourceId)
+				}
+			}
+
+			resourceIdValues = append(resourceIdValues, idsTmp...)
+		} else {
+			resourceIdValues = append(resourceIdValues, cr.ResourceIds...)
+		}
+	}
+
+	return serviceValue, resourceIdValues, nil
+}
+
+func (a *AwsCostExplorerSpiderCostCollector) GetCostInfo(ctx context.Context, param UpdateCostInfoParam) (CostInfos, error) {
+	serviceFilterValue, resourceIdFilterValue, err := a.generateFilterValue(param.CostResources, param.AwsAdditionalInfo)
+	if err != nil {
+		utils.LogError("parsing service and resource id for filtering cost explorer value")
+		return nil, err
+	}
+
+	if len(serviceFilterValue) == 0 || len(resourceIdFilterValue) == 0 {
+		return nil, ErrRequestResourceEmpty
+	}
+
+	granularity := "DAILY"
+	metrics := "UnblendedCost"
+	costWithResourceReq := costWithResourceReq{
+		StartDate:   param.StartDate.Format("2006-01-02"),
+		EndDate:     param.EndDate.Format("2006-01-02"),
+		Granularity: granularity,
+		Metrics:     []string{metrics}, // BlendedCost, UnblendedCost, ...
+		Filter: filterExpression{
+			Or: []*filterExpression{
+				{
+					And: []*filterExpression{
+						{
+							Dimensions: &keyValues{
+								Key:    "RESOURCE_ID",
+								Values: resourceIdFilterValue,
+							},
+						},
+						{
+							Dimensions: &keyValues{
+								Key:    "SERVICE",
+								Values: serviceFilterValue,
+							},
+						},
+					},
+				},
+				{
+					Dimensions: &keyValues{
+						Key: "SERVICE",
+						Values: []string{
+							string(constant.AwsCostExplorer),
+							string(constant.AwsTax),
+						},
+					},
+				},
+			},
+		},
+		// the order of group by will effect the result's key order
+		Groups: []groupBy{
+			{
+				Key:  "SERVICE",
+				Type: "DIMENSION",
+			},
+			{
+				Key:  "RESOURCE_ID",
+				Type: "DIMENSION",
+			},
+		},
+	}
+
+	m, err := json.Marshal(costWithResourceReq)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := a.sc.GetCostWithResourceWithContext(
+		ctx,
+		spider.AnycallReq{
+			ConnectionName: param.ConnectionName,
+			ReqInfo: spider.ReqInfo{
+				FID: "getCostWithResource",
+				IKeyValueList: []spider.KeyValue{
+					{
+						Key:   "requestBody",
+						Value: string(m),
+					},
+				},
+			},
+		},
+	)
+
+	if err != nil {
+		if errors.Is(err, spider.ErrSpiderCostResultEmpty) {
+			utils.LogError("error from spider: ", err)
+			return nil, ErrCostResultEmpty
+		}
+		return nil, err
+	}
+
+	if res == nil || res.ResultsByTime == nil || len(res.ResultsByTime) == 0 {
+		utils.LogError("cost result is empty: ")
+		return nil, ErrCostResultEmpty
+	}
+
+	var costInfos = make([]CostInfo, 0)
+	for _, result := range res.ResultsByTime {
+		if result.Groups == nil {
+			utils.LogError("groups is nil; it must not be nil")
+			return nil, ErrCostResultFormatInvalid
+		}
+
+		if result.TimePeriod == nil || result.TimePeriod.Start == nil || result.TimePeriod.End == nil {
+			utils.LogError("time period is nil; it must not be nil")
+			return nil, ErrCostResultFormatInvalid
+		}
+
+		for _, group := range result.Groups {
+
+			if group == nil {
+				utils.LogError("sinble group is nil; it must not be nil")
+				continue
+			}
+
+			category := utils.NilSafeStr(group.Keys[0])
+			awsService := constant.AwsService(category)
+			resourceType, ok := serviceToResourceType[awsService]
+			if !ok {
+				utils.LogErrorf("service : %s does not exist; category: %s", awsService, category)
+				continue
+			}
+			mt, ok := group.Metrics[metrics]
+			if !ok {
+				utils.LogError("matric value does not exist:", metrics)
+				continue
+			}
+			cost, err := strconv.ParseFloat(utils.NilSafeStr(mt.Amount), 64)
+			if err != nil {
+				utils.LogError("cost parsing error:", mt.Amount)
+				continue
+			}
+			unit := utils.NilSafeStr(mt.Unit)
+			formattedResourceId := utils.NilSafeStr(group.Keys[1])
+			actualResourceId := formattedResourceId
+
+			if strings.Contains(formattedResourceId, "/") {
+				splitedResource := strings.Split(actualResourceId, "/")
+				actualResourceId = splitedResource[len(splitedResource)-1]
+			}
+
+			startDate, err := time.Parse(time.RFC3339, utils.NilSafeStr(result.TimePeriod.Start))
+			if err != nil {
+				utils.LogError("start date parsing error:", result.TimePeriod.Start)
+				continue
+			}
+
+			endDate, err := time.Parse(time.RFC3339, utils.NilSafeStr(result.TimePeriod.End))
+			if err != nil {
+				utils.LogError("end date parsing error to ")
+				continue
+			}
+
+			costInfo := CostInfo{
+				MigrationId:         param.MigrationId,
+				Provider:            param.Provider,
+				ConnectionName:      param.ConnectionName,
+				ResourceType:        resourceType,
+				Category:            category,
+				Cost:                cost,
+				Unit:                unit,
+				ActualResourceId:    actualResourceId,
+				FormattedResourceId: formattedResourceId,
+				Granularity:         granularity,
+				StartDate:           startDate,
+				EndDate:             endDate,
+			}
+
+			costInfos = append(costInfos, costInfo)
+		}
+	}
+
+	return costInfos, nil
+}

--- a/internal/core/cost/models.go
+++ b/internal/core/cost/models.go
@@ -1,6 +1,8 @@
 package cost
 
 import (
+	"time"
+
 	"github.com/cloud-barista/cm-ant/internal/core/common/constant"
 	"gorm.io/gorm"
 )
@@ -28,4 +30,28 @@ type PriceInfo struct {
 	OriginalCurrency       string
 	CalculatedMonthlyPrice string
 	PriceDescription       string
+}
+
+type CostInfos []CostInfo
+
+type CostInfo struct {
+	gorm.Model
+	MigrationId         string
+	Provider            string
+	ConnectionName      string
+	ResourceType        constant.ResourceType
+	Category            string
+	Cost                float64
+	Unit                string
+	ActualResourceId    string
+	FormattedResourceId string
+	Granularity         string
+	StartDate           time.Time
+	EndDate             time.Time
+}
+
+type CostUpdateRestrict struct {
+	gorm.Model
+	StandardDate time.Time
+	UpdateCount  int64
 }

--- a/internal/core/cost/models.go
+++ b/internal/core/cost/models.go
@@ -36,18 +36,18 @@ type CostInfos []CostInfo
 
 type CostInfo struct {
 	gorm.Model
-	MigrationId         string
-	Provider            string
+	MigrationId         string `gorm:"index"`
+	Provider            string `gorm:"index"`
 	ConnectionName      string
-	ResourceType        constant.ResourceType
-	Category            string
+	ResourceType        constant.ResourceType `gorm:"index"`
+	Category            string                `gorm:"index"`
 	Cost                float64
 	Unit                string
-	ActualResourceId    string
+	ActualResourceId    string `gorm:"index"`
 	FormattedResourceId string
-	Granularity         string
-	StartDate           time.Time
-	EndDate             time.Time
+	Granularity         string    `gorm:"index"`
+	StartDate           time.Time `gorm:"index"`
+	EndDate             time.Time `gorm:"index"`
 }
 
 type CostUpdateRestrict struct {

--- a/internal/core/cost/repository.go
+++ b/internal/core/cost/repository.go
@@ -185,7 +185,7 @@ func (r *CostRepository) UpsertCostInfo(ctx context.Context, costInfo CostInfo) 
 
 }
 
-func (r *CostRepository) GetCostInfoWithFilter(ctx context.Context, param GetCostInfoParam) (any, error) {
+func (r *CostRepository) GetCostInfoWithFilter(ctx context.Context, param GetCostInfoParam) ([]GetCostInfoResult, error) {
 	var costInfo []GetCostInfoResult
 
 	err := r.execInTransaction(ctx, func(d *gorm.DB) error {

--- a/internal/core/cost/service.go
+++ b/internal/core/cost/service.go
@@ -505,15 +505,15 @@ func (c *CostService) UpdateCostInfo(param UpdateCostInfoParam) (UpdateCostInfoR
 }
 
 type GetCostInfoParam struct {
-	StartDate           time.Time                    
-	EndDate             time.Time                    
-	MigrationIds        []string                     
-	Providers           []string                     
-	ResourceTypes       []constant.ResourceType      
-	ResourceIds         []string                     
-	CostAggregationType constant.CostAggregationType 
-	DateOrder           constant.OrderType           
-	ResourceTypeOrder   constant.OrderType           
+	StartDate           time.Time
+	EndDate             time.Time
+	MigrationIds        []string
+	Providers           []string
+	ResourceTypes       []constant.ResourceType
+	ResourceIds         []string
+	CostAggregationType constant.CostAggregationType
+	DateOrder           constant.OrderType
+	ResourceTypeOrder   constant.OrderType
 }
 
 type GetCostInfoResult struct {
@@ -526,7 +526,7 @@ type GetCostInfoResult struct {
 	TotalCost        float64   `json:"totalCost"`
 }
 
-func (c *CostService) GetCostInfos(param GetCostInfoParam) (any, error) {
+func (c *CostService) GetCostInfos(param GetCostInfoParam) ([]GetCostInfoResult, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
 	defer cancel()
 	r, err := c.costRepo.GetCostInfoWithFilter(ctx, param)
@@ -535,6 +535,3 @@ func (c *CostService) GetCostInfos(param GetCostInfoParam) (any, error) {
 	}
 	return r, nil
 }
-
-// func (c *CostService) GetCostExpect(param GetPriceInfoParam) (AllPriceInfoResult, error) {
-// }

--- a/internal/core/cost/service.go
+++ b/internal/core/cost/service.go
@@ -504,10 +504,37 @@ func (c *CostService) UpdateCostInfo(param UpdateCostInfoParam) (UpdateCostInfoR
 	return updateCostInfoResult, nil
 }
 
+type GetCostInfoParam struct {
+	StartDate           time.Time                    
+	EndDate             time.Time                    
+	MigrationIds        []string                     
+	Providers           []string                     
+	ResourceTypes       []constant.ResourceType      
+	ResourceIds         []string                     
+	CostAggregationType constant.CostAggregationType 
+	DateOrder           constant.OrderType           
+	ResourceTypeOrder   constant.OrderType           
+}
 
-// func (c *CostService) GetCostInfos(param GetPriceInfoParam) (AllPriceInfoResult, error) {
-// }
+type GetCostInfoResult struct {
+	Provider         string    `json:"provider"`
+	ResourceType     string    `json:"resourceType"`
+	Category         string    `json:"category"`
+	ActualResourceId string    `json:"resourceId"`
+	Unit             string    `json:"unit"`
+	Date             time.Time `json:"date"`
+	TotalCost        float64   `json:"totalCost"`
+}
 
+func (c *CostService) GetCostInfos(param GetCostInfoParam) (any, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	defer cancel()
+	r, err := c.costRepo.GetCostInfoWithFilter(ctx, param)
+	if err != nil {
+		return nil, err
+	}
+	return r, nil
+}
 
 // func (c *CostService) GetCostExpect(param GetPriceInfoParam) (AllPriceInfoResult, error) {
 // }

--- a/internal/infra/db/db.go
+++ b/internal/infra/db/db.go
@@ -28,6 +28,7 @@ func migrateDB(defaultDb *gorm.DB) error {
 		&load.LoadTestExecutionState{},
 
 		&cost.PriceInfo{},
+		&cost.CostInfo{},
 	)
 
 	if err != nil {

--- a/internal/infra/outbound/spider/price.go
+++ b/internal/infra/outbound/spider/price.go
@@ -3,6 +3,7 @@ package spider
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -42,4 +43,49 @@ func (s *SpiderClient) GetPriceInfoWithContext(ctx context.Context, regionName s
 	}
 
 	return cloudPriceData, nil
+}
+
+var (
+	ErrSpiderCostResultEmpty = errors.New("cost information does not exist")
+)
+
+func (s *SpiderClient) GetCostWithResourceWithContext(ctx context.Context, body AnycallReq) (*CostWithResourcesRes, error) {
+	var anycallRes AnycallRes
+	var costWithResourceRes CostWithResourcesRes
+
+	url := s.withUrl("/anycall")
+
+	marshalledBody, err := json.Marshal(body)
+	if err != nil {
+		log.Println("marshalling body error;", err)
+		return &costWithResourceRes, err
+	}
+
+	resBytes, err := s.requestWithContext(ctx, http.MethodPost, url, marshalledBody, nil)
+
+	if err != nil {
+		utils.LogError("error sending get cost info data request:", err)
+
+		return &costWithResourceRes, fmt.Errorf("failed to send request: %w", err)
+	}
+
+	err = json.Unmarshal(resBytes, &anycallRes)
+
+	if err != nil {
+		utils.LogError("error unmarshaling response body:", err)
+		return &costWithResourceRes, fmt.Errorf("failed to unmarshal response body: %w", err)
+	}
+
+	if anycallRes.OKeyValueList == nil || len(anycallRes.IKeyValueList) == 0 {
+		return &costWithResourceRes, ErrSpiderCostResultEmpty
+	}
+
+	err = json.Unmarshal([]byte(anycallRes.OKeyValueList[0].Value), &costWithResourceRes)
+
+	if err != nil {
+		utils.LogError("error unmarshaling :", err)
+		return &costWithResourceRes, fmt.Errorf("failed to unmarshal response body: %w", err)
+	}
+
+	return &costWithResourceRes, nil
 }

--- a/internal/infra/outbound/spider/req.go
+++ b/internal/infra/outbound/spider/req.go
@@ -9,3 +9,17 @@ type FilterReq struct {
 	Key   string `json:"Key"`
 	Value string `json:"Value"`
 }
+
+type AnycallReq struct {
+	ConnectionName string `json:"ConnectionName"`
+	ReqInfo        ReqInfo `json:"ReqInfo"`
+}
+type ReqInfo struct {
+	FID           string     `json:"FID"`
+	IKeyValueList []KeyValue `json:"IKeyValueList"`
+}
+
+type KeyValue struct {
+	Key   string `json:"Key"`
+	Value string `json:"Value"`
+}

--- a/internal/infra/outbound/spider/res.go
+++ b/internal/infra/outbound/spider/res.go
@@ -71,3 +71,48 @@ type PricingPolicyInfoRes struct {
 	OfferingClass       string `json:"OfferingClass"`
 	PurchaseOption      string `json:"PurchaseOption"`
 }
+
+type AnycallRes struct {
+	FID           string     `json:"FID"`
+	IKeyValueList []KeyValue `json:"IKeyValueList"`
+	OKeyValueList []KeyValue `json:"OKeyValueList"`
+}
+
+type CostWithResourcesRes struct {
+	DimensionValueAttributes []*DimensionValuesWithAttributes `json:"DimensionValueAttributes"`
+	GroupDefinitions         []*GroupDefinition               `json:"GroupDefinitions"`
+	NextPageToken            *string                          `json:"NextPageToken"`
+	ResultsByTime            []*ResultByTime                  `json:"ResultsByTime"`
+}
+
+type DimensionValuesWithAttributes struct {
+	Attributes map[string]*string `json:"Attributes"`
+	Value      *string            `json:"Value"`
+}
+
+type GroupDefinition struct {
+	Key  *string `json:"Key"`
+	Type *string `json:"Type"`
+}
+
+type ResultByTime struct {
+	Estimated  *bool                   `json:"Estimated"`
+	Groups     []*Group                `json:"Groups"`
+	TimePeriod *DateInterval           `json:"TimePeriod"`
+	Total      map[string]*MetricValue `json:"Total"`
+}
+
+type Group struct {
+	Keys    []*string               `json:"Keys"`
+	Metrics map[string]*MetricValue `json:"Metrics"`
+}
+
+type DateInterval struct {
+	End   *string `json:"End"`
+	Start *string `json:"Start"`
+}
+
+type MetricValue struct {
+	Amount *string `json:"Amount"`
+	Unit   *string `json:"Unit"`
+}

--- a/internal/utils/strfunc.go
+++ b/internal/utils/strfunc.go
@@ -53,3 +53,10 @@ func ReplaceAtIndex(from string, newValue string, delim string, index int) (stri
 	parts[index] = newValue
 	return strings.Join(parts, delim), nil
 }
+
+func NilSafeStr(o *string) string {
+	if o == nil {
+		return ""
+	}
+	return *o
+}


### PR DESCRIPTION
# 작업 내용
- 마이그레이션 된 인프라의 정보를 사용자에게 받아 aws 의 사용자 비용 데이터 조회 및 저장
- 저장된 가격 정보에 대해서 일별, 주간별, 월별 비용 데이터 조회

## 리소스 타입 및 필요 정보
- VM
  - i-xxxxx 형식의 resource id
- VNet
  - eni-xxxxxx 형식의 ENI resource id
  - eipalloc-xxxxx 형식의 elastic ip resource id
    - eni , eip 에 대한 비용 데이터를 업데이트 하는 경우 실제 필터링이 가능한 리소스 아이디 조합을 위하여 아래 데이터를 필수로 넘겨줘야합니다.
    ```
    type AwsAdditionalInfoReq struct {
	  OwnerId string   `json:"ownerId"`  // 12자리 숫자값
	  Regions []string `json:"regions"`
    }
    ```
    
- DataDisk
  - vol-xxxx 형식의 EBS 볼륨 resource id
- CostExplorer
  - cost explorer api 는 페이지 요청당 0.01$ 의 과금을 청구하며 사용자의 credential 을 사용하여 cost explorer 를 호출하는 것이기 때문에 해당 resource type 은 추가하였습니다.
- Tax

## 상세 내용
- 로컬에서 개발한 spider 의 anycall handler 를 통하여 호출 테스트를 진행하였으며, aws 의 cost explorer api 를 통해 가격 정보를 호출합니다.
- **spider 의 aws anycall handler 에서 해당 기능이 머지된 후 해당 api 는 정상적으로 사용이 가능합니다.**
  - 해당 기능에 대해선 로컬에서 작업한 내용을 보완하여 spider pr 예정입니다.
- cost explorer 에 resource Id 를 통한 조회 기능은 오늘 기준으로 최대 2주내의 정보에 대해서만 조회 가능합니다.
  - aws cost explorer 의 정책이기 때문에 바꿀 수 없음
- cost explorer api 의 getCostAndUsageWithResources api 를 사용해서 마이그레이션 된 리소스 정보에 대한 가격 정보만 조회합니다.

## 개선 가능 사항
- 만일 workflow id 를 통해 마이그레이션 된 resource 에 대한 정보를 제공하는 api 가 서브시스템에 생긴다면 migration id 를 통해 특정 migration 에서 생성된 resource 정보를 조회함으로써 비용 업데이트시 필요한 요청 정보가 줄어들 수 있습니다.
  - resource id, owner id, region, connection 에 대한 정보가 필요 없어질 것으로 예상됩니다.
- 비용데이터가 일정 기간 이상 쌓이는 경우 시계열 데이터 예측 모델을 적용하여 비용 데이터에 대한 예측 비용을 제공 가능성도 있어보입니다.

