### PR TITLE
bug fix for estimate forecast cost group by then count query

### DIFF
--- a/internal/core/cost/repository.go
+++ b/internal/core/cost/repository.go
@@ -262,16 +262,17 @@ func (r *CostRepository) GetEstimateForecastCostInfosTx(ctx context.Context, par
 				Group("provider, resource_type, category, actual_resource_id, unit, date")
 		}
 
+
+		if err := d.Table("(?) AS sub", query).Count(&totalRows).Error; err != nil {
+			return err
+		}
+
 		if param.DateOrder != "" {
 			query = query.Order("date " + string(param.DateOrder))
 		}
 
 		if param.ResourceTypeOrder != "" {
 			query = query.Order("resource_type " + string(param.ResourceTypeOrder))
-		}
-
-		if err := query.Count(&totalRows).Error; err != nil {
-			return err
 		}
 
 		offset := (param.Page - 1) * param.Size


### PR DESCRIPTION
- group by 한 쿼리에 count() 를 호출하면 select count(*) 과 같이 group by 한 컬럼에 대해서 select 가 일어나지 않기 때문에 column not exists error 발생
- group by query 를 subquery 로 select 한 후 count(*) 호출