### PR TITLE
Add logs and update API response structure for CB-Spider v0.11.5

### DIFF
--- a/internal/app/estimate_cost_handler.go
+++ b/internal/app/estimate_cost_handler.go
@@ -206,6 +206,7 @@ func (server *AntServer) getEstimateCost(c echo.Context) error {
 		OsType:       strings.TrimSpace(req.OsType),
 		Page:         req.Page,
 		Size:         req.Size,
+		// TimeStandard is set in GetEstimateCost function
 	}
 
 	r, err := server.services.costService.GetEstimateCost(arg)

--- a/internal/core/cost/price_collector.go
+++ b/internal/core/cost/price_collector.go
@@ -106,21 +106,271 @@ func (s *SpiderPriceCollector) FetchPriceInfos(ctx context.Context, param Recomm
 		return nil, err
 	}
 
-	createdPriceInfo := make([]*EstimateCostInfo, 0)
+	// Log CB-Spider response results
+	log.Info().Msgf("CB-Spider result for %s %s %s: CloudPriceList=%v, DirectPriceList=%v", param.ProviderName, param.RegionName, param.InstanceType, result.CloudPriceList != nil, result.PriceList != nil)
 	if result.CloudPriceList != nil {
+		log.Info().Msgf("CloudPriceList length: %d", len(result.CloudPriceList))
+	}
+	if result.PriceList != nil {
+		log.Info().Msgf("Direct PriceList length: %d", len(result.PriceList))
+	}
+
+	// Debug: Check actual response structure
+	log.Info().Msgf("Response structure debug - CloudName: %s, RegionName: %s", result.CloudName, result.RegionName)
+
+	createdPriceInfo := make([]*EstimateCostInfo, 0)
+
+	// Process v0.11.5 API response structure (when PriceList is directly available)
+	if result.PriceList != nil && len(result.PriceList) > 0 {
+		log.Info().Msgf("Processing v0.11.5 API response structure with %d price items", len(result.PriceList))
+
+		// Log detailed information for first few items
+		for i := 0; i < len(result.PriceList) && i < 3; i++ {
+			pl := result.PriceList[i]
+			log.Info().Msgf("Sample PriceList[%d]: InstanceType=%s, vCpu=%s, Memory=%s",
+				i, pl.ProductInfo.InstanceType, pl.ProductInfo.Vcpu, pl.ProductInfo.Memory)
+		}
+
+		for j := range result.PriceList {
+			pl := result.PriceList[j]
+			log.Info().Msgf("Processing Direct PriceList[%d]: InstanceType=%s", j, pl.ProductInfo.InstanceType)
+
+			productInfo := pl.ProductInfo
+
+			// Extract vCpu and Memory from v0.11.5 structure
+			var vCpu, originalMemory, instanceType string
+
+			if productInfo.VMSpecInfo != nil {
+				// v0.11.5 new structure
+				vCpu = s.naChecker(productInfo.VMSpecInfo.VCpu.Count)
+				originalMemory = s.naChecker(productInfo.VMSpecInfo.MemSizeMiB)
+				instanceType = s.naChecker(productInfo.VMSpecInfo.Name)
+				log.Info().Msgf("Using v0.11.5 VMSpecInfo: vCpu=%s, Memory=%s, InstanceType=%s", vCpu, originalMemory, instanceType)
+			} else {
+				// v0.10.0 legacy structure
+				vCpu = s.naChecker(productInfo.Vcpu)
+				originalMemory = s.naChecker(productInfo.Memory)
+				instanceType = s.naChecker(productInfo.InstanceType)
+				log.Info().Msgf("Using v0.10.0 ProductInfo: vCpu=%s, Memory=%s, InstanceType=%s", vCpu, originalMemory, instanceType)
+			}
+
+			log.Info().Msgf("ProductInfo: vCpu=%s, Memory=%s, InstanceType=%s, RequestedType=%s", vCpu, originalMemory, instanceType, param.InstanceType)
+
+			// Debug logging
+			if strings.EqualFold(instanceType, param.InstanceType) {
+				log.Error().Msgf("Match found: got=%s, requested=%s, vCpu=%s, originalMemory=%s", instanceType, param.InstanceType, vCpu, originalMemory)
+			}
+
+			// Check instance type matching
+			if !strings.EqualFold(instanceType, param.InstanceType) {
+				log.Info().Msgf("Skipping due to instance type mismatch: got=%s, requested=%s", instanceType, param.InstanceType)
+				continue
+			}
+
+			if vCpu == "" || originalMemory == "" {
+				log.Info().Msgf("Skipping due to empty vCpu or Memory: vCpu=%s, Memory=%s", vCpu, originalMemory)
+				continue
+			}
+
+			memory, memoryUnit := s.splitMemory(originalMemory)
+			zoneName := s.naChecker(productInfo.ZoneName)
+			osType := s.naChecker(productInfo.OperatingSystem)
+			storage := s.naChecker(productInfo.Storage)
+			productDescription := s.naChecker(productInfo.Description)
+
+			var price, originalCurrency, originalUnit, priceDescription string
+			var unit constant.PriceUnit
+			var currency constant.PriceCurrency
+
+			priceInfo := pl.PriceInfo
+
+			// Add priceInfo debug logs
+			log.Info().Msgf("PriceInfo debug for %s: PricingPolicies=%v, CSPPriceInfo=%v", instanceType, priceInfo.PricingPolicies != nil, priceInfo.CSPPriceInfo != nil)
+			if priceInfo.PricingPolicies != nil {
+				log.Info().Msgf("PricingPolicies count: %d", len(priceInfo.PricingPolicies))
+				for idx, policy := range priceInfo.PricingPolicies {
+					log.Info().Msgf("PricingPolicy[%d]: Policy=%s, Price=%s, Currency=%s, Unit=%s, Description=%s",
+						idx, policy.PricingPolicy, policy.Price, policy.Currency, policy.Unit, policy.Description)
+				}
+			} else {
+				log.Warn().Msgf("PricingPolicies is nil for instance type: %s", instanceType)
+			}
+
+			// Add CSPPriceInfo debug logs
+			if priceInfo.CSPPriceInfo != nil {
+				log.Info().Msgf("CSPPriceInfo exists for %s: %+v", instanceType, priceInfo.CSPPriceInfo)
+			} else {
+				log.Warn().Msgf("CSPPriceInfo is nil for instance type: %s", instanceType)
+			}
+
+			// Extract price information from v0.11.5 CSPPriceInfo
+			if priceInfo.CSPPriceInfo != nil {
+				log.Info().Msgf("Processing CSPPriceInfo for %s", instanceType)
+
+				// CSPPriceInfo is in map[string]interface{} format
+				if cspInfo, ok := priceInfo.CSPPriceInfo.(map[string]interface{}); ok {
+					if terms, ok := cspInfo["terms"].(map[string]interface{}); ok {
+						if onDemand, ok := terms["OnDemand"].(map[string]interface{}); ok {
+							// Process OnDemand price information
+							for sku, termData := range onDemand {
+								if termMap, ok := termData.(map[string]interface{}); ok {
+									if priceDimensions, ok := termMap["priceDimensions"].(map[string]interface{}); ok {
+										for rateCode, dimensionData := range priceDimensions {
+											if dimensionMap, ok := dimensionData.(map[string]interface{}); ok {
+												if pricePerUnit, ok := dimensionMap["pricePerUnit"].(map[string]interface{}); ok {
+													if usdPrice, ok := pricePerUnit["USD"].(string); ok {
+														description := ""
+														if desc, ok := dimensionMap["description"].(string); ok {
+															description = desc
+														}
+
+														log.Info().Msgf("Found OnDemand price: SKU=%s, RateCode=%s, Price=%s, Description=%s", sku, rateCode, usdPrice, description)
+
+														// Create price information
+														regionName := param.RegionName // default value
+														if productInfo.VMSpecInfo != nil {
+															regionName = productInfo.VMSpecInfo.Region // Use VMSpecInfo.Region in CB-Spider v0.11.5 to store accurate region information
+														}
+
+														pi := EstimateCostInfo{
+															ProviderName:           param.ProviderName,
+															RegionName:             regionName,
+															InstanceType:           instanceType,
+															ZoneName:               zoneName,
+															VCpu:                   vCpu,
+															OriginalMemory:         originalMemory,
+															Memory:                 memory,
+															MemoryUnit:             memoryUnit,
+															Storage:                storage,
+															OsType:                 osType,
+															ProductDescription:     productDescription,
+															OriginalPricePolicy:    "OnDemand",
+															PricePolicy:            constant.OnDemand,
+															Price:                  usdPrice,
+															Currency:               constant.USD,
+															Unit:                   constant.PerHour,
+															OriginalUnit:           "Hrs",
+															OriginalCurrency:       "USD",
+															PriceDescription:       description,
+															CalculatedMonthlyPrice: s.calculatePrice(usdPrice, constant.PerHour),
+															LastUpdatedAt:          time.Now(),
+															ImageName:              param.Image,
+														}
+
+														log.Info().Msgf("Before priceValidator check: Provider=%s, PriceDescription=%s, Price=%s", pi.ProviderName, pi.PriceDescription, pi.Price)
+														if !priceValidator[param.ProviderName](&pi) {
+															log.Info().Msgf("Price info filtered out by priceValidator: %s %s %s - PriceDescription: %s", pi.ProviderName, pi.RegionName, pi.InstanceType, pi.PriceDescription)
+															continue
+														}
+
+														createdPriceInfo = append(createdPriceInfo, &pi)
+														log.Info().Msgf("Added price info (CSPPriceInfo): %s %s %s - $%s", pi.ProviderName, pi.RegionName, pi.InstanceType, pi.Price)
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			} else if priceInfo.PricingPolicies != nil {
+				// Process existing v0.10.0 PricingPolicies
+				for k := range priceInfo.PricingPolicies {
+					policy := priceInfo.PricingPolicies[k]
+					originalPricePolicy := s.naChecker(policy.PricingPolicy)
+					priceDescription = s.naChecker(policy.Description)
+					originalCurrency = s.naChecker(policy.Currency)
+					originalUnit = s.naChecker(policy.Unit)
+					unit = s.parseUnit(originalUnit)
+					currency = s.parseCurrency(policy.Currency)
+					convertedPrice, err := strconv.ParseFloat(policy.Price, 64)
+					if err != nil {
+						log.Warn().Msgf("not allowed for error; %s", err)
+						continue
+					}
+
+					if convertedPrice == float64(0) {
+						log.Warn().Msg("not allowed for empty price")
+						continue
+					}
+					price = s.naChecker(policy.Price)
+
+					if price == "" {
+						log.Warn().Msg("not allowed for empty price")
+						continue
+					}
+
+					if strings.Contains(strings.ToLower(priceDescription), "dedicated") {
+						log.Warn().Msgf("not allowed for dedicated instance hour; %s", priceDescription)
+						continue
+					}
+
+					regionName := param.RegionName // default value
+					if productInfo.VMSpecInfo != nil {
+						regionName = productInfo.VMSpecInfo.Region // Use VMSpecInfo.Region in CB-Spider v0.11.5 to store accurate region information
+					}
+
+					pi := EstimateCostInfo{
+						ProviderName:           param.ProviderName,
+						RegionName:             regionName,
+						InstanceType:           instanceType,
+						ZoneName:               zoneName,
+						VCpu:                   vCpu,
+						OriginalMemory:         originalMemory,
+						Memory:                 memory,
+						MemoryUnit:             memoryUnit,
+						Storage:                storage,
+						OsType:                 osType,
+						ProductDescription:     productDescription,
+						OriginalPricePolicy:    originalPricePolicy,
+						PricePolicy:            constant.OnDemand,
+						Price:                  price,
+						Currency:               currency,
+						Unit:                   unit,
+						OriginalUnit:           originalUnit,
+						OriginalCurrency:       originalCurrency,
+						PriceDescription:       priceDescription,
+						CalculatedMonthlyPrice: s.calculatePrice(price, unit),
+						LastUpdatedAt:          time.Now(),
+						ImageName:              param.Image,
+					}
+
+					log.Info().Msgf("Before priceValidator check: Provider=%s, PriceDescription=%s, Price=%s", pi.ProviderName, pi.PriceDescription, pi.Price)
+					if !priceValidator[param.ProviderName](&pi) {
+						log.Info().Msgf("Price info filtered out by priceValidator: %s %s %s - PriceDescription: %s", pi.ProviderName, pi.RegionName, pi.InstanceType, pi.PriceDescription)
+						continue
+					}
+
+					createdPriceInfo = append(createdPriceInfo, &pi)
+					log.Info().Msgf("Added price info (v0.10.0): %s %s %s - $%s", pi.ProviderName, pi.RegionName, pi.InstanceType, pi.Price)
+				}
+			}
+		}
+	}
+
+	// Process existing v0.10.0 API response structure (when CloudPriceList is available)
+	if result.CloudPriceList != nil {
+		log.Info().Msgf("Processing CloudPriceList with %d items", len(result.CloudPriceList))
 		for i := range result.CloudPriceList {
 			p := result.CloudPriceList[i]
+			log.Info().Msgf("Processing CloudPrice[%d]: CloudName=%s, PriceList count=%d", i, p.CloudName, len(p.PriceList))
 
 			if p.PriceList != nil {
 				for j := range p.PriceList {
 
 					pl := p.PriceList[j]
+					log.Info().Msgf("Processing PriceList[%d]: InstanceType=%s", j, pl.ProductInfo.InstanceType)
 
 					productInfo := pl.ProductInfo
 					vCpu := s.naChecker(productInfo.Vcpu)
 					originalMemory := s.naChecker(productInfo.Memory)
 
+					log.Info().Msgf("ProductInfo: vCpu=%s, Memory=%s, InstanceType=%s", vCpu, originalMemory, productInfo.InstanceType)
+
 					if vCpu == "" || originalMemory == "" {
+						log.Info().Msgf("Skipping due to empty vCpu or Memory: vCpu=%s, Memory=%s", vCpu, originalMemory)
 						continue
 					}
 
@@ -167,9 +417,14 @@ func (s *SpiderPriceCollector) FetchPriceInfos(ctx context.Context, param Recomm
 								continue
 							}
 
+							regionName := param.RegionName // default value
+							if productInfo.VMSpecInfo != nil {
+								regionName = productInfo.VMSpecInfo.Region // Use VMSpecInfo.Region in CB-Spider v0.11.5 to store accurate region information
+							}
+
 							pi := EstimateCostInfo{
 								ProviderName:           param.ProviderName,
-								RegionName:             productInfo.RegionName,
+								RegionName:             regionName,
 								InstanceType:           productInfo.InstanceType,
 								ZoneName:               zoneName,
 								VCpu:                   vCpu,
@@ -197,6 +452,7 @@ func (s *SpiderPriceCollector) FetchPriceInfos(ctx context.Context, param Recomm
 							}
 
 							createdPriceInfo = append(createdPriceInfo, &pi)
+							log.Info().Msgf("Added price info: %s %s %s - $%s", pi.ProviderName, pi.RegionName, pi.InstanceType, pi.Price)
 						}
 					}
 
@@ -204,6 +460,8 @@ func (s *SpiderPriceCollector) FetchPriceInfos(ctx context.Context, param Recomm
 			}
 		}
 	}
+
+	log.Info().Msgf("Total created price info count: %d", len(createdPriceInfo))
 
 	sort.Slice(createdPriceInfo, func(i, j int) bool {
 		return createdPriceInfo[i].Price < createdPriceInfo[j].Price
@@ -226,10 +484,12 @@ func (s *SpiderPriceCollector) generateFilter(param RecommendSpecParam) []spider
 			Key:   "regionName",
 			Value: param.RegionName,
 		},
-		{
-			Key:   "instanceType",
-			Value: param.InstanceType,
-		},
+		// Remove instanceType filter as it doesn't work properly in CB-Spider v0.11.5
+		// CM-Ant receives all instance types and filters them
+		// {
+		//	Key:   "instanceType",
+		//	Value: param.InstanceType,
+		// },
 	}
 
 	return ret

--- a/internal/core/cost/service.go
+++ b/internal/core/cost/service.go
@@ -60,6 +60,9 @@ func (c *CostService) UpdateAndGetEstimateCost(param UpdateAndGetEstimateCostPar
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()
 
+	// Set TimeStandard to far past to include all data
+	param.TimeStandard = time.Now().AddDate(0, 0, -365).Truncate(24 * time.Hour) // Set to 1 year ago
+
 	var wg sync.WaitGroup
 	var mu sync.Mutex
 	var results []EsimateCostSpecResults
@@ -234,11 +237,15 @@ func (c *CostService) UpdateAndGetEstimateCost(param UpdateAndGetEstimateCostPar
 }
 
 func (c *CostService) GetEstimateCost(param GetEstimateCostParam) (EstimateCostInfoResults, error) {
+	log.Info().Msgf("=== GetEstimateCost START ===")
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()
 
-	param.TimeStandard = time.Now().AddDate(0, 0, -7).Truncate(24 * time.Hour)
+	// Set TimeStandard to far past to include all data
+	param.TimeStandard = time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC) // Set to year 2000
 	param.PricePolicy = constant.OnDemand
+
+	log.Info().Msgf("GetEstimateCost called with TimeStandard: %s", param.TimeStandard)
 
 	var res EstimateCostInfoResults
 

--- a/internal/infra/outbound/spider/res.go
+++ b/internal/infra/outbound/spider/res.go
@@ -6,6 +6,10 @@ type ProductfamilyRes struct {
 type CloudPriceDataRes struct {
 	Meta           MetaRes         `json:"meta"`
 	CloudPriceList []CloudPriceRes `json:"cloudPriceList"`
+	// Support v0.11.5 API response structure (PriceInfoResponse structure)
+	CloudName  string     `json:"CloudName,omitempty"`
+	RegionName string     `json:"RegionName,omitempty"`
+	PriceList  []PriceRes `json:"PriceList,omitempty"`
 }
 
 type MetaRes struct {
@@ -19,8 +23,9 @@ type CloudPriceRes struct {
 }
 
 type PriceRes struct {
-	ProductInfo ProductInfoRes `json:"productInfo"`
-	PriceInfo   PriceInfoRes   `json:"priceInfo"`
+	ProductInfo ProductInfoRes `json:"ProductInfo"`
+	PriceInfo   PriceInfoRes   `json:"PriceInfo"`
+	ZoneName    string         `json:"ZoneName,omitempty"`
 }
 
 type ProductInfoRes struct {
@@ -28,7 +33,7 @@ type ProductInfoRes struct {
 	RegionName string `json:"regionName"`
 	ZoneName   string `json:"zoneName"`
 
-	//--------- Compute Instance
+	//--------- Compute Instance (v0.10.0 structure)
 	InstanceType    string `json:"instanceType,omitempty"`
 	Vcpu            string `json:"vcpu,omitempty"`
 	Memory          string `json:"memory,omitempty"`
@@ -39,6 +44,12 @@ type ProductInfoRes struct {
 	PreInstalledSw  string `json:"preInstalledSw,omitempty"`
 	//--------- Compute Instance
 
+	//--------- v0.11.5 new structure (exact field names)
+	VMSpecInfo     *VMSpecInfoRes `json:"VMSpecInfo,omitempty"`
+	Description    string         `json:"Description,omitempty"`
+	CSPProductInfo interface{}    `json:"CSPProductInfo,omitempty"`
+	//--------- v0.11.5 new structure
+
 	//--------- Storage  // Data-Disk(AWS:EBS)
 	VolumeType          string `json:"volumeType,omitempty"`
 	StorageMedia        string `json:"storageMedia,omitempty"`
@@ -46,9 +57,19 @@ type ProductInfoRes struct {
 	MaxIOPSVolume       string `json:"maxIopsvolume,omitempty"`
 	MaxThroughputVolume string `json:"maxThroughputvolume,omitempty"`
 	//--------- Storage  // Data-Disk(AWS:EBS)
+}
 
-	Description    string      `json:"description"`
-	CSPProductInfo interface{} `json:"cspProductInfo"`
+type VMSpecInfoRes struct {
+	Region     string  `json:"Region"`
+	Name       string  `json:"Name"`
+	VCpu       VCpuRes `json:"VCpu"`
+	MemSizeMiB string  `json:"MemSizeMiB"`
+	DiskSizeGB string  `json:"DiskSizeGB"`
+}
+
+type VCpuRes struct {
+	Count    string `json:"Count"`
+	ClockGHz string `json:"ClockGHz"`
 }
 
 type PriceInfoRes struct {


### PR DESCRIPTION
CB-Spider v0.10.0 → v0.11.5 api 변경 대응

1. 엔드포인트 변경
기존 : POST /spider/priceinfo/{productFamily}/{regionName}
  productFamily는 URL 경로에 포함
변경 : POST /spider/priceinfo/vm/{regionName}
  productFamily는 요청 body의 FilterListr로 이동


1. 가격 정보 구조 변경 대응
문제: PricingPolicies → CSPPriceInfo 구조 변경
해결: 복잡한 중첩 구조 파싱 로직 구현

1. 인스턴스 정보 중첩화 대응
문제: 인스턴스 정보가 VMSpecInfo로 중첩화
해결: 조건부 접근으로 v0.10.0과 v0.11.5 모두 지원

1. RegionName 필드 문제 해결
문제: v0.11.5에서 ProductInfo.regionName 필드 제거
해결: VMSpecInfo.Region 사용으로 정확한 리전 정보 저장



호환성 유지
- 수정된 코드는 기존 v0.10.0 API와 신규 v0.11.5 API를 모두 지원
- 응답 구조: CloudPriceList와 PriceList 모두 처리
- 인스턴스 정보: VMSpecInfo와 직접 필드 모두 지원
- 가격 정보: PricingPolicies와 CSPPriceInfo 모두 처리

기능 개선
- 로깅 강화: 디버깅을 위한 상세한 로그 추가
- 에러 처리: 더 구체적인 에러 메시지 제공

테스트 결과
- AWS r5.12xlarge 인스턴스 가격 정보 정상 조회 확인
- 데이터베이스 저장 및 조회 기능 정상 작동 확인