### PR TITLE
Refactor load configuration to support multi-cloud provider fallback …

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -45,23 +45,32 @@ load:
       centos: ["centos", "rhel"]
       amazon: ["amazon", "amzn"]
     
-    # AWS 리전별 기본 이미지 목록 (스마트 매칭 실패 시 폴백용)
-    awsImages:
-      "ap-northeast-2": "ami-0f37ba4f1a9f199d1"  # Ubuntu 22.04 LTS (최신)
-      "ap-southeast-1": "ami-0f37ba4f1a9f199d1"  # Ubuntu 22.04 LTS
-      "us-east-1": "ami-0f37ba4f1a9f199d1"       # Ubuntu 22.04 LTS
-      "us-west-2": "ami-0f37ba4f1a9f199d1"       # Ubuntu 22.04 LTS
+    # 멀티 CSP 지원을 위한 폴백 이미지 설정 (스마트 매칭 실패 시 사용)
+    fallbackImages:
+      aws:
+        "ap-northeast-2": "ami-0f37ba4f1a9f199d1"  # Ubuntu 22.04 LTS (최신)
+        "ap-southeast-1": "ami-0f37ba4f1a9f199d1"  # Ubuntu 22.04 LTS
+        "us-east-1": "ami-0f37ba4f1a9f199d1"       # Ubuntu 22.04 LTS
+        "us-west-2": "ami-0f37ba4f1a9f199d1"       # Ubuntu 22.04 LTS
+      azure:
+        "koreacentral": "Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:latest"
+        "eastus": "Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:latest"
+      gcp:
+        "asia-northeast3": "ubuntu-2204-jammy-v20231213"
+        "us-central1": "ubuntu-2204-jammy-v20231213"
+      ncp:
+        "KR": "SW.VSVR.OS.LNX64.UBNTU.SVR2004.LTS"
   spec:
     # VM 스펙 요구사항 (Load Generator용)
     # minVcpu: 2        # 최소 vCPU
     # maxVcpu: 8        # 최대 vCPU (기존 8에서 2로 변경)
     # minMemory: 4      # 최소 메모리 (GB)
     # maxMemory: 8      # 최대 메모리 (GB) (기존 8에서 4로 변경)
-    minVcpu: 2        # 최소 vCPU
-    maxVcpu: 4        # 최대 vCPU (기존 8에서 2로 변경)
-    minMemory: 1      # 최소 메모리 (GB)
-    maxMemory: 4      # 최대 메모리 (GB) (기존 8에서 4로 변경)
-    provider: "aws"   # 클라우드 프로바이더
+    minVcpu: 2        # 최소 vCPU (for medium)
+    maxVcpu: 4        # 최대 vCPU
+    minMemory: 4      # 최소 메모리 (GB)(for medium)
+    maxMemory: 8      # 최대 메모리 (GB)
+    # provider 제거 - 동적으로 기존 VM의 CSP 정보에서 추출
     # 아키텍처 제한: x86_64 (ARM64와 호환되지 않는 AMI 사용)
     architecture: "x86_64"  # x86_64 아키텍처 강제 사용
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -57,18 +57,18 @@ type AntConfig struct {
 			Version string `yaml:"version"`
 		} `yaml:"jmeter"`
 		Image struct {
-			UseSmartMatching bool                `yaml:"useSmartMatching"`
-			PreferredOs      string              `yaml:"preferredOs"`
-			FallbackOs       string              `yaml:"fallbackOs"`
-			OsKeywords       map[string][]string `yaml:"osKeywords"`
-			AwsImages        map[string]string   `yaml:"awsImages"`
+			UseSmartMatching bool                         `yaml:"useSmartMatching"`
+			PreferredOs      string                       `yaml:"preferredOs"`
+			FallbackOs       string                       `yaml:"fallbackOs"`
+			OsKeywords       map[string][]string          `yaml:"osKeywords"`
+			FallbackImages   map[string]map[string]string `yaml:"fallbackImages"`
 		} `yaml:"image"`
 		Spec struct {
-			MinVcpu      int    `yaml:"minVcpu"`
-			MaxVcpu      int    `yaml:"maxVcpu"`
-			MinMemory    int    `yaml:"minMemory"`
-			MaxMemory    int    `yaml:"maxMemory"`
-			Provider     string `yaml:"provider"`
+			MinVcpu   int `yaml:"minVcpu"`
+			MaxVcpu   int `yaml:"maxVcpu"`
+			MinMemory int `yaml:"minMemory"`
+			MaxMemory int `yaml:"maxMemory"`
+			// Provider 제거 - 동적으로 기존 VM의 CSP 정보에서 추출
 			Architecture string `yaml:"architecture"`
 		} `yaml:"spec"`
 	} `yaml:"load"`

--- a/internal/core/load/dtos.go
+++ b/internal/core/load/dtos.go
@@ -43,6 +43,10 @@ type GetAllMonitoringAgentInfoResult struct {
 type InstallLoadGeneratorParam struct {
 	InstallLocation constant.InstallLocation `json:"installLocation,omitempty"`
 	Coordinates     []string                 `json:"coordinate"`
+	// VM 정보 추가 (CSP 매칭용)
+	NsId  string `json:"nsId,omitempty"`
+	MciId string `json:"mciId,omitempty"`
+	VmId  string `json:"vmId,omitempty"`
 }
 
 type LoadGeneratorServerResult struct {

--- a/internal/core/load/load_test_execution_service.go
+++ b/internal/core/load/load_test_execution_service.go
@@ -100,7 +100,13 @@ func (l *LoadService) processLoadTestAsync(param RunLoadTestParam, loadTestExecu
 	if param.LoadGeneratorInstallInfoId == uint(0) {
 		log.Info().Msgf("No LoadGeneratorInstallInfoId provided, installing load generator...")
 
-		result, err := l.InstallLoadGenerator(param.InstallLoadGenerator)
+		// ✅ VM 정보를 부하 발생기 설치 파라미터에 추가
+		installParam := param.InstallLoadGenerator
+		installParam.NsId = param.NsId
+		installParam.MciId = param.MciId
+		installParam.VmId = param.VmId
+
+		result, err := l.InstallLoadGenerator(installParam)
 		if err != nil {
 			failed(fmt.Sprintf("Error installing load generator: %v", err), err)
 			return

--- a/internal/infra/outbound/tumblebug/mci.go
+++ b/internal/infra/outbound/tumblebug/mci.go
@@ -35,6 +35,32 @@ func (t *TumblebugClient) GetMciWithContext(ctx context.Context, nsId, mciId str
 	return mciObject, nil
 }
 
+// GetVmWithContext retrieves specific VM information
+func (t *TumblebugClient) GetVmWithContext(ctx context.Context, nsId, mciId, vmId string) (VmInfo, error) {
+	var vmObject VmInfo
+
+	url := t.withUrl(fmt.Sprintf("/ns/%s/mci/%s/vm/%s", nsId, mciId, vmId))
+	resBytes, err := t.requestWithBaseAuthWithContext(ctx, http.MethodGet, url, nil)
+
+	if err != nil {
+		log.Error().Msgf("error sending get vm request; %v", err)
+
+		if errors.Is(err, ErrInternalServerError) {
+			return vmObject, ErrNotFound
+		}
+		return vmObject, fmt.Errorf("failed to send request: %w", err)
+	}
+
+	err = json.Unmarshal(resBytes, &vmObject)
+
+	if err != nil {
+		log.Error().Msgf("error unmarshaling response body; %v", err)
+		return vmObject, fmt.Errorf("failed to unmarshal response body: %w", err)
+	}
+
+	return vmObject, nil
+}
+
 // GetAvailableImagesWithContext retrieves available images for a specific connection
 func (t *TumblebugClient) GetAvailableImagesWithContext(ctx context.Context, connectionName string) ([]ImageInfo, error) {
 	var response struct {

--- a/internal/infra/outbound/tumblebug/req.go
+++ b/internal/infra/outbound/tumblebug/req.go
@@ -103,10 +103,41 @@ type VmReq struct {
 }
 
 type RecommendVmReq struct {
-	Filter   Filter   `json:"filter"`
-	Limit    string   `json:"limit"`
-	Priority Priority `json:"priority"`
+	Filter   FilterInfo   `json:"filter"`
+	Limit    string       `json:"limit"`
+	Priority PriorityInfo `json:"priority"`
 }
+
+// CB-Tumblebug v0.11.9+ 구조체들
+type FilterInfo struct {
+	Policy []FilterCondition `json:"policy"`
+}
+
+type FilterCondition struct {
+	Metric    string      `json:"metric"`
+	Condition []Operation `json:"condition"`
+}
+
+type Operation struct {
+	Operator string `json:"operator"` // >=, <=, ==
+	Operand  string `json:"operand"`
+}
+
+type PriorityInfo struct {
+	Policy []PriorityCondition `json:"policy"`
+}
+
+type PriorityCondition struct {
+	Metric    string      `json:"metric"`
+	Parameter []Parameter `json:"parameter"`
+}
+
+type Parameter struct {
+	Key string   `json:"key"`
+	Val []string `json:"val"`
+}
+
+// 하위 호환성을 위한 기존 구조체들 (deprecated)
 type Condition struct {
 	Operand  string `json:"operand"`
 	Operator string `json:"operator"`
@@ -117,10 +148,6 @@ type FilterPolicy struct {
 }
 type Filter struct {
 	Policy []FilterPolicy `json:"policy"`
-}
-type Parameter struct {
-	Key string   `json:"key"`
-	Val []string `json:"val"`
 }
 type Policy struct {
 	Metric    string      `json:"metric"`


### PR DESCRIPTION
- 부하 발생기 설치 타임아웃 설정 문제 수정
- 부하 발생 머신 생성 리전 불일치 문제 수정
- 부하 발생 머신 생성 리전과 다른 리전의 이미지 검색 문제 수정
- 스마트 이미지 검색 실패 시 fallback Images를 AWS에서 멀티 CSP 방식으로 변경
- 부하 발생기 기본 스펙 환경 설정 값을 Medium 스펙으로 상향 조정
- 스펙에서 프로바이더 종속성 제거