### PR TITLE
Refactor image retrieval logic to return an error when no available images

### DIFF
--- a/internal/core/load/load_generator_install_service.go
+++ b/internal/core/load/load_generator_install_service.go
@@ -807,10 +807,8 @@ func (l *LoadService) getAvailableImageTraditional(ctx context.Context, connecti
 		}
 	}
 
-	// 기본 이미지 사용
-	defaultImage := "ami-0f37ba4f1a9f199d1" // Ubuntu 22.04 LTS (최신)
-	log.Info().Msgf("Using default image for provider %s, region %s: %s", provider, region, defaultImage)
-	return defaultImage, nil
+	// 폴백 이미지도 없는 경우 에러 반환
+	return "", fmt.Errorf("no available image found for provider %s, region %s. Please check CB-Tumblebug image availability or configure fallback images in config.yaml", provider, region)
 }
 
 // extractProviderAndRegionFromConnection extracts provider and region from connection name


### PR DESCRIPTION
- 스마트 이미지 검색 및 폴백 이미지로도 못 찾을 경우 하드코딩된 aws 이미지가 리턴되는 버그 수정