### PR TITLE
Add GitHub Actions workflows for force rebuilding and retagging Docker images

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,101 @@
+# GitHub Actions Workflows
+
+이 디렉토리는 CM-ANT 프로젝트의 GitHub Actions 워크플로우를 포함합니다.
+
+## 기존 워크플로우
+
+### 1. Continuous Integration (CI)
+- **파일**: `continuous-integration.yaml`
+- **트리거**: Pull Request 생성/업데이트
+- **기능**: 소스 코드 빌드 및 컨테이너 이미지 빌드 테스트
+
+### 2. Continuous Delivery (CD)
+- **파일**: `continuous-delivery.yaml`
+- **트리거**: 
+  - `main` 브랜치 푸시
+  - `v*.*.*` 형식의 태그 푸시
+- **기능**: Docker Hub 및 GHCR에 컨테이너 이미지 배포
+
+## 새로운 워크플로우
+
+### 3. Retag Release
+- **파일**: `retag-release.yaml`
+- **트리거**: 수동 실행 (`workflow_dispatch`)
+- **기능**: 기존 태그를 삭제하고 최신 커밋으로 재생성
+
+#### 사용법:
+1. GitHub 리포지토리의 **Actions** 탭으로 이동
+2. **Retag Release** 워크플로우 선택
+3. **Run workflow** 버튼 클릭
+4. 입력값 설정:
+   - `tag_name`: 재생성할 태그명 (예: `v0.4.0`)
+   - `confirm_deletion`: `DELETE` 입력 (확인용)
+
+#### 주의사항:
+- ⚠️ **기존 태그가 완전히 삭제됩니다**
+- Docker Hub에서 해당 태그의 모든 이미지가 제거됩니다
+- 삭제 후 30초 대기 후 새 이미지 빌드 시작
+
+### 4. Force Rebuild Tag
+- **파일**: `force-rebuild.yaml`
+- **트리거**: 수동 실행 (`workflow_dispatch`)
+- **기능**: 기존 태그를 유지하면서 최신 코드로 강제 재빌드
+
+#### 사용법:
+1. GitHub 리포지토리의 **Actions** 탭으로 이동
+2. **Force Rebuild Tag** 워크플로우 선택
+3. **Run workflow** 버튼 클릭
+4. 입력값 설정:
+   - `tag_name`: 재빌드할 태그명 (예: `v0.4.0`)
+   - `force_rebuild`: `REBUILD` 입력 (확인용)
+
+#### 특징:
+- 기존 태그는 유지됩니다
+- 캐시를 사용하지 않고 완전히 새로 빌드합니다
+- Docker Hub의 태그 충돌 문제를 해결합니다
+
+## 문제 해결 시나리오
+
+### 시나리오 1: Docker Hub에서 같은 태그에 여러 digest 존재
+```bash
+# 문제: v0.4.0 태그가 두 개의 다른 digest를 가리킴
+# 해결: Retag Release 워크플로우 사용
+```
+
+### 시나리오 2: 최신 코드가 반영되지 않은 이미지
+```bash
+# 문제: 태그는 최신이지만 이미지 내용이 오래됨
+# 해결: Force Rebuild Tag 워크플로우 사용
+```
+
+### 시나리오 3: 일반적인 새 릴리즈
+```bash
+# 방법: 기존 CD 워크플로우 사용
+git tag v0.4.1
+git push origin v0.4.1
+```
+
+## 필요한 GitHub Secrets
+
+다음 Secrets이 설정되어 있어야 합니다:
+
+- `DOCKER_USERNAME`: Docker Hub 사용자명
+- `DOCKER_PASSWORD`: Docker Hub 비밀번호 또는 액세스 토큰
+- `CR_PAT`: GitHub Container Registry Personal Access Token
+
+## 워크플로우 실행 권한
+
+- **cloud-barista** 조직의 멤버만 워크플로우를 실행할 수 있습니다
+- 포크된 리포지토리에서는 실행할 수 없습니다 (보안상의 이유)
+
+## 트러블슈팅
+
+### 워크플로우가 실행되지 않는 경우
+1. GitHub Secrets 설정 확인
+2. 리포지토리 권한 확인
+3. 입력값 형식 확인 (태그명은 `v0.4.0` 형식)
+
+### Docker Hub API 오류
+1. Docker Hub 계정 권한 확인
+2. API 레이트 리미트 확인
+3. 네트워크 연결 상태 확인

--- a/.github/workflows/force-rebuild.yaml
+++ b/.github/workflows/force-rebuild.yaml
@@ -1,0 +1,107 @@
+# This workflow forces a rebuild of a specific tag without deleting the existing one
+# Useful when you want to ensure the latest code is built with an existing tag
+name: Force Rebuild Tag
+
+on:
+  # Manual workflow dispatch with input parameters
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Tag name to rebuild (e.g., v0.4.0)'
+        required: true
+        type: string
+      force_rebuild:
+        description: 'Force rebuild (type "REBUILD" to confirm)'
+        required: true
+        type: string
+
+env:
+  DOCKER_REGISTRY_NAME: cloudbaristaorg
+  IMAGE_NAME: ${{ github.event.repository.name }}
+
+jobs:
+  force-rebuild:
+    name: Force Rebuild Tag
+    runs-on: ubuntu-22.04
+    
+    # Only allow if confirmation is provided
+    if: github.event.inputs.force_rebuild == 'REBUILD'
+    
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate tag format
+        run: |
+          TAG_NAME="${{ github.event.inputs.tag_name }}"
+          if [[ ! $TAG_NAME =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Error: Tag name must follow semver format (e.g., v0.4.0)"
+            exit 1
+          fi
+          echo "Validating tag: $TAG_NAME"
+
+      - name: Extract metadata for tag
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{env.DOCKER_REGISTRY_NAME}}/${{env.IMAGE_NAME}}
+          tags: |
+            type=raw,value=${{ github.event.inputs.tag_name }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: all
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Clear Docker cache (force fresh build)
+        run: |
+          docker buildx prune -f
+          rm -rf /tmp/.buildx-cache || true
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and publish (force rebuild)
+        id: docker_build
+        uses: docker/build-push-action@v6
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          context: ./
+          file: ./Dockerfile
+          target: prod
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          # Force rebuild by not using cache
+          no-cache: true
+
+      - name: Verify rebuild
+        run: |
+          TAG_NAME="${{ github.event.inputs.tag_name }}"
+          echo "Verifying rebuilt tag: $TAG_NAME"
+          
+          # Wait for Docker Hub to process
+          sleep 10
+          
+          # Get tag info
+          TAG_INFO=$(curl -s "https://hub.docker.com/v2/repositories/${{ env.DOCKER_REGISTRY_NAME }}/${{ env.IMAGE_NAME }}/tags/$TAG_NAME/")
+          echo "Tag info: $TAG_INFO"
+          
+          echo "Tag $TAG_NAME successfully rebuilt with digest: ${{ steps.docker_build.outputs.digest }}"
+
+      - name: Summary
+        run: |
+          echo "## Force Rebuild Summary" >> $GITHUB_STEP_SUMMARY
+          echo "- **Tag**: ${{ github.event.inputs.tag_name }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **New Digest**: ${{ steps.docker_build.outputs.digest }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Commit**: ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Status**: ✅ Successfully rebuilt" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/retag-release.yaml
+++ b/.github/workflows/retag-release.yaml
@@ -1,0 +1,127 @@
+# This workflow allows manual retagging of existing releases
+# It deletes the existing tag from Docker Hub and recreates it with the latest commit
+name: Retag Release
+
+on:
+  # Manual workflow dispatch with input parameters
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Tag name to retag (e.g., v0.4.0)'
+        required: true
+        type: string
+      confirm_deletion:
+        description: 'Confirm deletion of existing tag (type "DELETE" to confirm)'
+        required: true
+        type: string
+
+env:
+  DOCKER_REGISTRY_NAME: cloudbaristaorg
+  IMAGE_NAME: ${{ github.event.repository.name }}
+
+jobs:
+  retag-release:
+    name: Retag Release
+    runs-on: ubuntu-22.04
+    
+    # Only allow if confirmation is provided
+    if: github.event.inputs.confirm_deletion == 'DELETE'
+    
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Fetch all history for proper tagging
+
+      - name: Validate tag format
+        run: |
+          TAG_NAME="${{ github.event.inputs.tag_name }}"
+          if [[ ! $TAG_NAME =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Error: Tag name must follow semver format (e.g., v0.4.0)"
+            exit 1
+          fi
+          echo "Validating tag: $TAG_NAME"
+
+      - name: Delete existing tag from Docker Hub
+        run: |
+          TAG_NAME="${{ github.event.inputs.tag_name }}"
+          echo "Deleting existing tag: $TAG_NAME"
+          
+          # Delete the tag from Docker Hub
+          curl -X DELETE \
+            -u ${{ secrets.DOCKER_USERNAME }}:${{ secrets.DOCKER_PASSWORD }} \
+            "https://hub.docker.com/v2/repositories/${{ env.DOCKER_REGISTRY_NAME }}/${{ env.IMAGE_NAME }}/tags/$TAG_NAME/" \
+            -H "Accept: application/json"
+          
+          echo "Tag $TAG_NAME deleted from Docker Hub"
+
+      - name: Wait for tag deletion
+        run: |
+          echo "Waiting 30 seconds for Docker Hub to process deletion..."
+          sleep 30
+
+      - name: Extract metadata for new tag
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{env.DOCKER_REGISTRY_NAME}}/${{env.IMAGE_NAME}}
+          tags: |
+            type=raw,value=${{ github.event.inputs.tag_name }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: all
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Cache Docker layers
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and publish retagged image
+        id: docker_build
+        uses: docker/build-push-action@v6
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          context: ./
+          file: ./Dockerfile
+          target: prod
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+
+      - name: Verify new tag
+        run: |
+          TAG_NAME="${{ github.event.inputs.tag_name }}"
+          echo "Verifying new tag: $TAG_NAME"
+          
+          # Wait a bit for Docker Hub to process
+          sleep 10
+          
+          # Check if tag exists
+          curl -s "https://hub.docker.com/v2/repositories/${{ env.DOCKER_REGISTRY_NAME }}/${{ env.IMAGE_NAME }}/tags/$TAG_NAME/" | jq '.name'
+          
+          echo "New tag $TAG_NAME successfully created with digest: ${{ steps.docker_build.outputs.digest }}"
+
+      - name: Summary
+        run: |
+          echo "## Retag Summary" >> $GITHUB_STEP_SUMMARY
+          echo "- **Tag**: ${{ github.event.inputs.tag_name }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **New Digest**: ${{ steps.docker_build.outputs.digest }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Commit**: ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Status**: ✅ Successfully retagged" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
- Introduced `force-rebuild.yaml` to allow manual rebuilding of existing tags without deletion, ensuring the latest code is built.
- Added `retag-release.yaml` for manual retagging of releases, which deletes the existing tag and recreates it with the latest commit.
- Updated `README.md` to document the new workflows, including usage instructions and troubleshooting scenarios.