### PR TITLE
fix: correct load-test parameter range validation (&& -> ||)

### DIFF
--- a/internal/app/evaluate_performance_handler.go
+++ b/internal/app/evaluate_performance_handler.go
@@ -182,22 +182,22 @@ func (s *AntServer) runLoadTest(c echo.Context) error {
 		req.TestName = uuid.New().String()
 	}
 
-	if v, err := strconv.Atoi(strings.TrimSpace(req.VirtualUsers)); err != nil && (v < 1 || v > 100) {
+	if v, err := strconv.Atoi(strings.TrimSpace(req.VirtualUsers)); err != nil || v < 1 || v > 100 {
 		log.Error().Msgf("virtual user count is invalid")
 		return errorResponseJson(http.StatusBadRequest, "virtual user  is not correct. the range must be in 1 to 100")
 	}
 
-	if v, err := strconv.Atoi(strings.TrimSpace(req.Duration)); err != nil && (v < 1 || v > 300) {
+	if v, err := strconv.Atoi(strings.TrimSpace(req.Duration)); err != nil || v < 1 || v > 300 {
 		log.Error().Msgf("duration is invalid")
 		return errorResponseJson(http.StatusBadRequest, "duration is not correct. the range must be in 1 to 300")
 	}
 
-	if v, err := strconv.Atoi(strings.TrimSpace(req.RampUpTime)); err != nil && (v < 1 || v > 60) {
+	if v, err := strconv.Atoi(strings.TrimSpace(req.RampUpTime)); err != nil || v < 1 || v > 60 {
 		log.Error().Msgf("ramp up time is invalid")
 		return errorResponseJson(http.StatusBadRequest, "ramp up time is not correct. the range must be in 1 to 60")
 	}
 
-	if v, err := strconv.Atoi(strings.TrimSpace(req.RampUpSteps)); err != nil && (v < 1 || v > 20) {
+	if v, err := strconv.Atoi(strings.TrimSpace(req.RampUpSteps)); err != nil || v < 1 || v > 20 {
 		log.Error().Msgf("ramp up steps is invalid")
 		return errorResponseJson(http.StatusBadRequest, "ramp up steps is not correct. the range must be in 1 to 20")
 	}
@@ -223,7 +223,7 @@ func (s *AntServer) runLoadTest(c echo.Context) error {
 			return errorResponseJson(http.StatusBadRequest, "load test running info is not correct.; Hostname")
 		}
 
-		if t, err := strconv.Atoi(h.Port); err != nil && (t < 1 || t > 65353) {
+		if t, err := strconv.Atoi(h.Port); err != nil || t < 1 || t > 65535 {
 			log.Error().Msgf("port range is not valid. check the range of ports")
 			return errorResponseJson(http.StatusBadRequest, "load test running info is not correct.; Port")
 		}

--- a/internal/app/evaluate_performance_handler_test.go
+++ b/internal/app/evaluate_performance_handler_test.go
@@ -1,0 +1,110 @@
+package app
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+)
+
+// invokeRunLoadTest builds a JSON request and calls runLoadTest, returning the
+// resulting *echo.HTTPError (nil if the handler returned no error).
+//
+// services is left nil on purpose: every assertion below stops at the request
+// validation stage, which runs before any loadService call, so no real service
+// or DB is required.
+func invokeRunLoadTest(t *testing.T, body string) *echo.HTTPError {
+	t.Helper()
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/load/tests/run", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	c := e.NewContext(req, httptest.NewRecorder())
+
+	s := &AntServer{}
+	err := s.runLoadTest(c)
+	if err == nil {
+		return nil
+	}
+	he, ok := err.(*echo.HTTPError)
+	if !ok {
+		t.Fatalf("expected *echo.HTTPError, got %T: %v", err, err)
+	}
+	return he
+}
+
+func httpErrMessage(he *echo.HTTPError) string {
+	if he == nil {
+		return ""
+	}
+	if ar, ok := he.Message.(AntResponse[string]); ok {
+		return ar.ErrorMessage
+	}
+	return ""
+}
+
+// TestRunLoadTest_ParamRangeValidation verifies the fixed range validation:
+//   - out-of-range parameters must be rejected with HTTP 400 (this is the
+//     regression that the `&&` bug previously let through),
+//   - in-range parameters must pass range validation (verified indirectly by
+//     stopping at the next check, "http request required", with empty httpReqs).
+func TestRunLoadTest_ParamRangeValidation(t *testing.T) {
+	const base = `"installLoadGenerator":{"installLocation":"local"}`
+
+	cases := []struct {
+		name      string
+		body      string
+		wantMsgIn string
+	}{
+		{
+			name:      "VirtualUsers over range (100000) -> 400",
+			body:      `{` + base + `,"virtualUsers":"100000","duration":"10","rampUpTime":"5","rampUpSteps":"2"}`,
+			wantMsgIn: "virtual user",
+		},
+		{
+			name:      "Duration over range (99999) -> 400",
+			body:      `{` + base + `,"virtualUsers":"10","duration":"99999","rampUpTime":"5","rampUpSteps":"2"}`,
+			wantMsgIn: "duration",
+		},
+		{
+			name:      "RampUpTime over range (9999) -> 400",
+			body:      `{` + base + `,"virtualUsers":"10","duration":"10","rampUpTime":"9999","rampUpSteps":"2"}`,
+			wantMsgIn: "ramp up time",
+		},
+		{
+			name:      "RampUpSteps over range (9999) -> 400",
+			body:      `{` + base + `,"virtualUsers":"10","duration":"10","rampUpTime":"5","rampUpSteps":"9999"}`,
+			wantMsgIn: "ramp up steps",
+		},
+		{
+			name:      "Port over range (99999) -> 400",
+			body:      `{` + base + `,"virtualUsers":"10","duration":"10","rampUpTime":"5","rampUpSteps":"2","httpReqs":[{"method":"GET","protocol":"http","hostname":"127.0.0.1","port":"99999","path":"/"}]}`,
+			wantMsgIn: "Port",
+		},
+		{
+			// In-range params must pass the range checks; with empty httpReqs the
+			// handler then stops at the "http request required" check (still 400 but
+			// a different message), proving the range validation did not reject them.
+			name:      "in-range params pass range validation",
+			body:      `{` + base + `,"virtualUsers":"100","duration":"300","rampUpTime":"60","rampUpSteps":"20","httpReqs":[]}`,
+			wantMsgIn: "http request",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			he := invokeRunLoadTest(t, tc.body)
+			if he == nil {
+				t.Fatalf("expected HTTP 400, got nil (range validation passed unexpectedly)")
+			}
+			if he.Code != http.StatusBadRequest {
+				t.Fatalf("expected 400, got %d (msg=%q)", he.Code, httpErrMessage(he))
+			}
+			if msg := httpErrMessage(he); !strings.Contains(msg, tc.wantMsgIn) {
+				t.Fatalf("expected message to contain %q, got %q", tc.wantMsgIn, msg)
+			}
+		})
+	}
+}

--- a/internal/app/evaluate_performance_handler_test.go
+++ b/internal/app/evaluate_performance_handler_test.go
@@ -46,10 +46,11 @@ func httpErrMessage(he *echo.HTTPError) string {
 }
 
 // TestRunLoadTest_ParamRangeValidation verifies the fixed range validation:
-//   - out-of-range parameters must be rejected with HTTP 400 (this is the
-//     regression that the `&&` bug previously let through),
-//   - in-range parameters must pass range validation (verified indirectly by
-//     stopping at the next check, "http request required", with empty httpReqs).
+//   - out-of-range values (above max AND below min) and non-numeric values
+//     must be rejected with HTTP 400 (the `&&` bug previously let valid
+//     out-of-range integers — both too-large and too-small, e.g. "0" — pass),
+//   - in-range values (including min/max boundaries) must pass range validation
+//     (verified by stopping at the next check, "http request required").
 func TestRunLoadTest_ParamRangeValidation(t *testing.T) {
 	const base = `"installLoadGenerator":{"installLocation":"local"}`
 
@@ -83,11 +84,47 @@ func TestRunLoadTest_ParamRangeValidation(t *testing.T) {
 			body:      `{` + base + `,"virtualUsers":"10","duration":"10","rampUpTime":"5","rampUpSteps":"2","httpReqs":[{"method":"GET","protocol":"http","hostname":"127.0.0.1","port":"99999","path":"/"}]}`,
 			wantMsgIn: "Port",
 		},
+
+		// --- below range (v < 1): also broken by the && bug ("0" previously passed) ---
 		{
-			// In-range params must pass the range checks; with empty httpReqs the
-			// handler then stops at the "http request required" check (still 400 but
-			// a different message), proving the range validation did not reject them.
-			name:      "in-range params pass range validation",
+			name:      "VirtualUsers below range (0) -> 400",
+			body:      `{` + base + `,"virtualUsers":"0","duration":"10","rampUpTime":"5","rampUpSteps":"2"}`,
+			wantMsgIn: "virtual user",
+		},
+		{
+			name:      "Duration below range (0) -> 400",
+			body:      `{` + base + `,"virtualUsers":"10","duration":"0","rampUpTime":"5","rampUpSteps":"2"}`,
+			wantMsgIn: "duration",
+		},
+		{
+			name:      "RampUpTime below range (0) -> 400",
+			body:      `{` + base + `,"virtualUsers":"10","duration":"10","rampUpTime":"0","rampUpSteps":"2"}`,
+			wantMsgIn: "ramp up time",
+		},
+		{
+			name:      "RampUpSteps below range (0) -> 400",
+			body:      `{` + base + `,"virtualUsers":"10","duration":"10","rampUpTime":"5","rampUpSteps":"0"}`,
+			wantMsgIn: "ramp up steps",
+		},
+		{
+			name:      "Port below range (0) -> 400",
+			body:      `{` + base + `,"virtualUsers":"10","duration":"10","rampUpTime":"5","rampUpSteps":"2","httpReqs":[{"method":"GET","protocol":"http","hostname":"127.0.0.1","port":"0","path":"/"}]}`,
+			wantMsgIn: "Port",
+		},
+		{
+			name:      "VirtualUsers non-numeric (abc) -> 400",
+			body:      `{` + base + `,"virtualUsers":"abc","duration":"10","rampUpTime":"5","rampUpSteps":"2"}`,
+			wantMsgIn: "virtual user",
+		},
+
+		// --- in-range boundaries must pass range validation (stop at http request check) ---
+		{
+			name:      "in-range min boundary (1/1/1/1) passes range validation",
+			body:      `{` + base + `,"virtualUsers":"1","duration":"1","rampUpTime":"1","rampUpSteps":"1","httpReqs":[]}`,
+			wantMsgIn: "http request",
+		},
+		{
+			name:      "in-range max boundary (100/300/60/20) passes range validation",
 			body:      `{` + base + `,"virtualUsers":"100","duration":"300","rampUpTime":"60","rampUpSteps":"20","httpReqs":[]}`,
 			wantMsgIn: "http request",
 		},


### PR DESCRIPTION
## Summary
Load-test parameter range checks in `internal/app/evaluate_performance_handler.go` used `err != nil && (out-of-range)`. When `strconv.Atoi` succeeds (a valid integer), the condition short-circuits to false, so the range check is effectively dead — an out-of-range value (both too large and too small, e.g. `0`) passes validation without returning HTTP 400.

This changes the condition to `err != nil || out-of-range` for the five affected fields so that non-numeric and out-of-range inputs are rejected with 400. The Port upper-bound typo `65353` is also corrected to `65535`. Range limits are unchanged.

## Affected fields (intended range)
- VirtualUsers (1–100)
- Duration (1–300)
- RampUpTime (1–60)
- RampUpSteps (1–20)
- Port (1–65535)

## Test
- Added `internal/app/evaluate_performance_handler_test.go` (`TestRunLoadTest_ParamRangeValidation`, 13 cases): over-range, below-range (`0`), and non-numeric inputs return 400; in-range min/max boundaries pass validation.
- `go build ./...` OK; `go test -vet=off ./internal/app/` 13/13 pass (the package has pre-existing, unrelated `printf` vet warnings, hence `-vet=off`).