### PR TITLE
feat(readyz): enforce dependency auth and add startup fail-fast check

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -1550,7 +1550,7 @@ const docTemplate = `{
         },
         "/readyz": {
             "get": {
-                "description": "This endpoint checks if the CB-Ant API server is ready by verifying the status of both the load service and the cost service. If either service is unavailable, it returns a 503 status indicating the server is not ready.",
+                "description": "Returns CM-Ant server readiness including DB and outbound\ndependency (cb-spider, cb-tumblebug) reachability and\nauthentication. Per STANDARD-READYZ pattern B, the response\nbody always carries per-dependency status; the HTTP status is\n200 when every dependency is reachable and authenticated, and\n503 otherwise. Results are cached briefly to limit outbound\ncall rate; see STANDARD-READYZ for details.",
                 "consumes": [
                     "application/json"
                 ],
@@ -1560,25 +1560,19 @@ const docTemplate = `{
                 "tags": [
                     "[Server Health]"
                 ],
-                "summary": "Check CB-Ant API server readiness",
+                "summary": "Check CM-Ant API server readiness",
                 "operationId": "AntServerReadiness",
                 "responses": {
                     "200": {
-                        "description": "CM-Ant API server is ready",
+                        "description": "CM-Ant is ready (all dependencies healthy)",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/app.readyzResponse"
                         }
                     },
                     "503": {
-                        "description": "CB-Ant API server is not ready",
+                        "description": "CM-Ant is not ready (see dependencies for the failing component)",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/app.readyzResponse"
                         }
                     }
                 }
@@ -1946,6 +1940,40 @@ const docTemplate = `{
                 }
             }
         },
+        "app.DepResult": {
+            "type": "object",
+            "properties": {
+                "db": {
+                    "$ref": "#/definitions/app.DepStatus"
+                },
+                "ready": {
+                    "type": "boolean"
+                },
+                "spider": {
+                    "$ref": "#/definitions/app.DepStatus"
+                },
+                "tumblebug": {
+                    "$ref": "#/definitions/app.DepStatus"
+                }
+            }
+        },
+        "app.DepStatus": {
+            "type": "object",
+            "properties": {
+                "authenticated": {
+                    "type": "boolean"
+                },
+                "error": {
+                    "type": "string"
+                },
+                "lastCheck": {
+                    "type": "string"
+                },
+                "reachable": {
+                    "type": "boolean"
+                }
+            }
+        },
         "app.InstallLoadGeneratorReq": {
             "type": "object",
             "properties": {
@@ -2159,6 +2187,23 @@ const docTemplate = `{
                 },
                 "nsId": {
                     "type": "string"
+                }
+            }
+        },
+        "app.readyzResponse": {
+            "type": "object",
+            "properties": {
+                "dependencies": {
+                    "$ref": "#/definitions/app.DepResult"
+                },
+                "initialized": {
+                    "type": "boolean"
+                },
+                "message": {
+                    "type": "string"
+                },
+                "ready": {
+                    "type": "boolean"
                 }
             }
         },
@@ -3025,7 +3070,7 @@ const docTemplate = `{
 
 // SwaggerInfo holds exported Swagger Info so clients can modify it
 var SwaggerInfo = &swag.Spec{
-	Version:          "0.4.0",
+	Version:          "0.5.2",
 	Host:             "",
 	BasePath:         "/ant",
 	Schemes:          []string{},

--- a/api/docs.go
+++ b/api/docs.go
@@ -3070,7 +3070,7 @@ const docTemplate = `{
 
 // SwaggerInfo holds exported Swagger Info so clients can modify it
 var SwaggerInfo = &swag.Spec{
-	Version:          "0.5.2",
+	Version:          "0.6.0",
 	Host:             "",
 	BasePath:         "/ant",
 	Schemes:          []string{},

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -4,7 +4,7 @@
         "description": "CM-ANT REST API swagger document.",
         "title": "CM-ANT REST API",
         "contact": {},
-        "version": "0.5.2"
+        "version": "0.6.0"
     },
     "basePath": "/ant",
     "paths": {

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -4,7 +4,7 @@
         "description": "CM-ANT REST API swagger document.",
         "title": "CM-ANT REST API",
         "contact": {},
-        "version": "0.4.0"
+        "version": "0.5.2"
     },
     "basePath": "/ant",
     "paths": {
@@ -1543,7 +1543,7 @@
         },
         "/readyz": {
             "get": {
-                "description": "This endpoint checks if the CB-Ant API server is ready by verifying the status of both the load service and the cost service. If either service is unavailable, it returns a 503 status indicating the server is not ready.",
+                "description": "Returns CM-Ant server readiness including DB and outbound\ndependency (cb-spider, cb-tumblebug) reachability and\nauthentication. Per STANDARD-READYZ pattern B, the response\nbody always carries per-dependency status; the HTTP status is\n200 when every dependency is reachable and authenticated, and\n503 otherwise. Results are cached briefly to limit outbound\ncall rate; see STANDARD-READYZ for details.",
                 "consumes": [
                     "application/json"
                 ],
@@ -1553,25 +1553,19 @@
                 "tags": [
                     "[Server Health]"
                 ],
-                "summary": "Check CB-Ant API server readiness",
+                "summary": "Check CM-Ant API server readiness",
                 "operationId": "AntServerReadiness",
                 "responses": {
                     "200": {
-                        "description": "CM-Ant API server is ready",
+                        "description": "CM-Ant is ready (all dependencies healthy)",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/app.readyzResponse"
                         }
                     },
                     "503": {
-                        "description": "CB-Ant API server is not ready",
+                        "description": "CM-Ant is not ready (see dependencies for the failing component)",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/app.readyzResponse"
                         }
                     }
                 }
@@ -1939,6 +1933,40 @@
                 }
             }
         },
+        "app.DepResult": {
+            "type": "object",
+            "properties": {
+                "db": {
+                    "$ref": "#/definitions/app.DepStatus"
+                },
+                "ready": {
+                    "type": "boolean"
+                },
+                "spider": {
+                    "$ref": "#/definitions/app.DepStatus"
+                },
+                "tumblebug": {
+                    "$ref": "#/definitions/app.DepStatus"
+                }
+            }
+        },
+        "app.DepStatus": {
+            "type": "object",
+            "properties": {
+                "authenticated": {
+                    "type": "boolean"
+                },
+                "error": {
+                    "type": "string"
+                },
+                "lastCheck": {
+                    "type": "string"
+                },
+                "reachable": {
+                    "type": "boolean"
+                }
+            }
+        },
         "app.InstallLoadGeneratorReq": {
             "type": "object",
             "properties": {
@@ -2152,6 +2180,23 @@
                 },
                 "nsId": {
                     "type": "string"
+                }
+            }
+        },
+        "app.readyzResponse": {
+            "type": "object",
+            "properties": {
+                "dependencies": {
+                    "$ref": "#/definitions/app.DepResult"
+                },
+                "initialized": {
+                    "type": "boolean"
+                },
+                "message": {
+                    "type": "string"
+                },
+                "ready": {
+                    "type": "boolean"
                 }
             }
         },

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -993,7 +993,7 @@ info:
   contact: {}
   description: CM-ANT REST API swagger document.
   title: CM-ANT REST API
-  version: 0.5.2
+  version: 0.6.0
 paths:
   /api/v1/cost/estimate:
     get:

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -233,6 +233,28 @@ definitions:
       resourceType:
         $ref: '#/definitions/constant.ResourceType'
     type: object
+  app.DepResult:
+    properties:
+      db:
+        $ref: '#/definitions/app.DepStatus'
+      ready:
+        type: boolean
+      spider:
+        $ref: '#/definitions/app.DepStatus'
+      tumblebug:
+        $ref: '#/definitions/app.DepStatus'
+    type: object
+  app.DepStatus:
+    properties:
+      authenticated:
+        type: boolean
+      error:
+        type: string
+      lastCheck:
+        type: string
+      reachable:
+        type: boolean
+    type: object
   app.InstallLoadGeneratorReq:
     properties:
       installLocation:
@@ -378,6 +400,17 @@ definitions:
         type: string
       nsId:
         type: string
+    type: object
+  app.readyzResponse:
+    properties:
+      dependencies:
+        $ref: '#/definitions/app.DepResult'
+      initialized:
+        type: boolean
+      message:
+        type: string
+      ready:
+        type: boolean
     type: object
   constant.ExecutionStatus:
     enum:
@@ -960,7 +993,7 @@ info:
   contact: {}
   description: CM-ANT REST API swagger document.
   title: CM-ANT REST API
-  version: 0.4.0
+  version: 0.5.2
 paths:
   /api/v1/cost/estimate:
     get:
@@ -2004,26 +2037,27 @@ paths:
     get:
       consumes:
       - application/json
-      description: This endpoint checks if the CB-Ant API server is ready by verifying
-        the status of both the load service and the cost service. If either service
-        is unavailable, it returns a 503 status indicating the server is not ready.
+      description: |-
+        Returns CM-Ant server readiness including DB and outbound
+        dependency (cb-spider, cb-tumblebug) reachability and
+        authentication. Per STANDARD-READYZ pattern B, the response
+        body always carries per-dependency status; the HTTP status is
+        200 when every dependency is reachable and authenticated, and
+        503 otherwise. Results are cached briefly to limit outbound
+        call rate; see STANDARD-READYZ for details.
       operationId: AntServerReadiness
       produces:
       - application/json
       responses:
         "200":
-          description: CM-Ant API server is ready
+          description: CM-Ant is ready (all dependencies healthy)
           schema:
-            additionalProperties:
-              type: string
-            type: object
+            $ref: '#/definitions/app.readyzResponse'
         "503":
-          description: CB-Ant API server is not ready
+          description: CM-Ant is not ready (see dependencies for the failing component)
           schema:
-            additionalProperties:
-              type: string
-            type: object
-      summary: Check CB-Ant API server readiness
+            $ref: '#/definitions/app.readyzResponse'
+      summary: Check CM-Ant API server readiness
       tags:
       - '[Server Health]'
 swagger: "2.0"

--- a/cmd/cm-ant/main.go
+++ b/cmd/cm-ant/main.go
@@ -21,7 +21,7 @@ import (
 // InitRouter initializes the routing for CM-ANT API server.
 
 // @title CM-ANT REST API
-// @version 0.4.0
+// @version 0.5.2
 // @description CM-ANT REST API swagger document.
 // @basePath /ant
 

--- a/cmd/cm-ant/main.go
+++ b/cmd/cm-ant/main.go
@@ -21,7 +21,7 @@ import (
 // InitRouter initializes the routing for CM-ANT API server.
 
 // @title CM-ANT REST API
-// @version 0.5.2
+// @version 0.6.0
 // @description CM-ANT REST API swagger document.
 // @basePath /ant
 

--- a/cmd/cm-ant/main.go
+++ b/cmd/cm-ant/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 
 	"os"
@@ -86,6 +87,17 @@ func main() {
 	if err != nil {
 		log.Fatal().Msgf("CM-Ant server creation error: %v", err)
 	}
+
+	// Fail-fast dependency check before accepting traffic. Per STANDARD-READYZ
+	// (cmig-workflow c-mig-common/design/07-DESIGN/STANDARD-READYZ.md §6.2),
+	// the container should not enter a "healthy but non-functional" state when
+	// DB, cb-spider, or cb-tumblebug are unreachable or misconfigured.
+	startupCtx, startupCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	if derr := s.CheckStartupDependencies(startupCtx); derr != nil {
+		startupCancel()
+		log.Fatal().Msgf("CM-Ant startup dependency check failed: %v", derr)
+	}
+	startupCancel()
 
 	// Initialize the router for the CM-Ant server
 	err = s.InitRouter()

--- a/internal/app/common_handler.go
+++ b/internal/app/common_handler.go
@@ -6,32 +6,47 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
+// readyzResponse is the response shape for GET /ant/readyz. It follows pattern
+// B of c-mig-common STANDARD-READYZ (cmig-workflow
+// c-mig-common/design/07-DESIGN/STANDARD-READYZ.md): a structured body that
+// callers can inspect for per-dependency reachable/authenticated state in
+// addition to the HTTP status code. cm-ant itself has no separate
+// initialization step, so Initialized is always true when Ready is true.
+type readyzResponse struct {
+	Ready        bool       `json:"ready"`
+	Initialized  bool       `json:"initialized"`
+	Message      string     `json:"message"`
+	Dependencies *DepResult `json:"dependencies"`
+}
+
 // @Id AntServerReadiness
-// @Summary Check CB-Ant API server readiness
-// @Description This endpoint checks if the CB-Ant API server is ready by verifying the status of both the load service and the cost service. If either service is unavailable, it returns a 503 status indicating the server is not ready.
+// @Summary Check CM-Ant API server readiness
+// @Description Returns CM-Ant server readiness including DB and outbound
+// @Description dependency (cb-spider, cb-tumblebug) reachability and
+// @Description authentication. Per STANDARD-READYZ pattern B, the response
+// @Description body always carries per-dependency status; the HTTP status is
+// @Description 200 when every dependency is reachable and authenticated, and
+// @Description 503 otherwise. Results are cached briefly to limit outbound
+// @Description call rate; see STANDARD-READYZ for details.
 // @Tags [Server Health]
 // @Accept json
 // @Produce json
-// @Success 200 {object} map[string]string "CM-Ant API server is ready"
-// @Failure 503 {object} map[string]string "CB-Ant API server is not ready"
+// @Success 200 {object} readyzResponse "CM-Ant is ready (all dependencies healthy)"
+// @Failure 503 {object} readyzResponse "CM-Ant is not ready (see dependencies for the failing component)"
 // @Router /readyz [get]
 func (s *AntServer) readyz(c echo.Context) error {
-	err := s.services.loadService.Readyz()
-	if err != nil {
-		return echo.NewHTTPError(http.StatusServiceUnavailable, map[string]string{
-			"message": "CM-Ant API server is not ready",
-		})
+	res := s.getDependencyStatus(c.Request().Context())
+
+	body := readyzResponse{
+		Ready:        res.Ready,
+		Initialized:  res.Ready,
+		Dependencies: res,
 	}
 
-	err = s.services.costService.Readyz()
-
-	if err != nil {
-		return echo.NewHTTPError(http.StatusServiceUnavailable, map[string]string{
-			"message": "CM-Ant API server is not ready",
-		})
+	if !res.Ready {
+		body.Message = "CM-Ant is not ready — see dependencies for the failing component"
+		return c.JSON(http.StatusServiceUnavailable, body)
 	}
-
-	return c.JSON(http.StatusOK, map[string]string{
-		"message": "CM-Ant API server is ready",
-	})
+	body.Message = "CM-Ant is ready"
+	return c.JSON(http.StatusOK, body)
 }

--- a/internal/app/common_handler.go
+++ b/internal/app/common_handler.go
@@ -44,7 +44,7 @@ func (s *AntServer) readyz(c echo.Context) error {
 	}
 
 	if !res.Ready {
-		body.Message = "CM-Ant is not ready — see dependencies for the failing component"
+		body.Message = "CM-Ant is not ready - see dependencies for the failing component"
 		return c.JSON(http.StatusServiceUnavailable, body)
 	}
 	body.Message = "CM-Ant is ready"

--- a/internal/app/dependency_check.go
+++ b/internal/app/dependency_check.go
@@ -1,0 +1,187 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/cloud-barista/cm-ant/internal/infra/outbound/spider"
+	"github.com/cloud-barista/cm-ant/internal/infra/outbound/tumblebug"
+	"gorm.io/gorm"
+)
+
+// depCacheTTL controls how long the /ant/readyz handler reuses a previous
+// dependency check result before re-checking. Per STANDARD-READYZ §8, this
+// limits outbound dependency call rate to at most one full check per TTL.
+// Startup uses CheckStartupDependencies which bypasses the cache.
+const depCacheTTL = 30 * time.Second
+
+// DepStatus captures the result of probing a single dependency.
+type DepStatus struct {
+	Reachable     bool      `json:"reachable"`
+	Authenticated bool      `json:"authenticated"`
+	LastCheck     time.Time `json:"lastCheck"`
+	Error         string    `json:"error,omitempty"`
+}
+
+// DepResult captures the result of probing all dependencies cm-ant needs to
+// service requests. Per STANDARD-READYZ §3, a dependency is considered fully
+// healthy only when both Reachable and Authenticated are true (cb-tumblebug
+// also requires Ready==true && Initialized==true; that check happens inside
+// tumblebug_client.ReadyzWithContext).
+type DepResult struct {
+	Ready     bool      `json:"ready"`
+	DB        DepStatus `json:"db"`
+	Spider    DepStatus `json:"spider"`
+	Tumblebug DepStatus `json:"tumblebug"`
+}
+
+type depCache struct {
+	mu      sync.Mutex
+	last    *DepResult
+	lastSet time.Time
+}
+
+// checkDependencies runs the full STANDARD-READYZ §3 check sequence:
+//  1. DB connectivity (gorm handle + Ping)
+//  2. cb-spider /readyz reachability
+//  3. cb-spider /cloudos with Basic Auth (auth enforcement)
+//  4. cb-tumblebug /readyz body inspection (Ready && Initialized)
+//  5. cb-tumblebug /cloudInfo with Basic Auth (auth enforcement)
+//
+// It always probes live; callers wanting the cached result should use
+// getDependencyStatus.
+func (s *AntServer) checkDependencies(ctx context.Context) *DepResult {
+	now := time.Now()
+	res := &DepResult{}
+
+	// 1. DB
+	res.DB = probeDB(ctx, s.db, now)
+
+	// 2/3. cb-spider
+	res.Spider = probeSpider(ctx, s.spiderClient, now)
+
+	// 4/5. cb-tumblebug
+	res.Tumblebug = probeTumblebug(ctx, s.tumblebugClient, now)
+
+	res.Ready = res.DB.Reachable && res.DB.Authenticated &&
+		res.Spider.Reachable && res.Spider.Authenticated &&
+		res.Tumblebug.Reachable && res.Tumblebug.Authenticated
+	return res
+}
+
+func probeDB(ctx context.Context, db *gorm.DB, now time.Time) DepStatus {
+	if db == nil {
+		return DepStatus{Reachable: false, LastCheck: now,
+			Error: "cm-ant DB connection is nil. Check ANT_DB_HOST/USER/PASSWORD and DB connectivity"}
+	}
+	sqlDB, err := db.DB()
+	if err != nil {
+		return DepStatus{Reachable: false, LastCheck: now,
+			Error: fmt.Sprintf("cm-ant DB handle 획득 실패: %v. Check DB driver/configuration", err)}
+	}
+	if err := sqlDB.PingContext(ctx); err != nil {
+		return DepStatus{Reachable: false, LastCheck: now,
+			Error: fmt.Sprintf("cm-ant DB ping 실패: %v. Check ANT_DB_HOST/USER/PASSWORD/network", err)}
+	}
+	// DB connectivity == authentication for DB (creds are part of the conn).
+	return DepStatus{Reachable: true, Authenticated: true, LastCheck: now}
+}
+
+func probeSpider(ctx context.Context, c *spider.SpiderClient, now time.Time) DepStatus {
+	if c == nil {
+		return DepStatus{Reachable: false, LastCheck: now,
+			Error: "cb-spider client is nil"}
+	}
+	endpoint := c.Endpoint()
+	if err := c.ReadyzWithContext(ctx); err != nil {
+		return DepStatus{Reachable: false, LastCheck: now,
+			Error: fmt.Sprintf("cb-spider 미응답 (host=%s): %v. Check cb-spider 컨테이너 상태·network", endpoint, err)}
+	}
+	if err := c.AuthCheckWithContext(ctx); err != nil {
+		if errors.Is(err, spider.ErrUnauthorized) {
+			return DepStatus{Reachable: true, Authenticated: false, LastCheck: now,
+				Error: fmt.Sprintf("cb-spider 인증 실패 (host=%s, HTTP 401). cm-ant 측 ANT_SPIDER_USERNAME/ANT_SPIDER_PASSWORD 환경변수 또는 config Spider.Username/Password 확인 필요", endpoint)}
+		}
+		return DepStatus{Reachable: true, Authenticated: false, LastCheck: now,
+			Error: fmt.Sprintf("cb-spider 인증 확인 호출 오류 (host=%s, GET /spider/cloudos): %v", endpoint, err)}
+	}
+	return DepStatus{Reachable: true, Authenticated: true, LastCheck: now}
+}
+
+func probeTumblebug(ctx context.Context, c *tumblebug.TumblebugClient, now time.Time) DepStatus {
+	if c == nil {
+		return DepStatus{Reachable: false, LastCheck: now,
+			Error: "cb-tumblebug client is nil"}
+	}
+	endpoint := c.Endpoint()
+	if err := c.ReadyzWithContext(ctx); err != nil {
+		switch {
+		case errors.Is(err, tumblebug.ErrNotReady):
+			return DepStatus{Reachable: false, LastCheck: now,
+				Error: fmt.Sprintf("cb-tumblebug 미응답 (host=%s): %v. Check cb-tumblebug 컨테이너 상태·network", endpoint, err)}
+		case errors.Is(err, tumblebug.ErrNotInitialized):
+			return DepStatus{Reachable: true, Authenticated: false, LastCheck: now,
+				Error: fmt.Sprintf("cb-tumblebug 초기화 미완료 (host=%s): %v. cb-tumblebug 초기화 절차 완료 필요", endpoint, err)}
+		default:
+			return DepStatus{Reachable: false, LastCheck: now,
+				Error: fmt.Sprintf("cb-tumblebug 미응답 (host=%s): %v. Check cb-tumblebug 컨테이너 상태·network", endpoint, err)}
+		}
+	}
+	if err := c.AuthCheckWithContext(ctx); err != nil {
+		if errors.Is(err, tumblebug.ErrUnauthorized) {
+			return DepStatus{Reachable: true, Authenticated: false, LastCheck: now,
+				Error: fmt.Sprintf("cb-tumblebug 인증 실패 (host=%s, HTTP 401). cm-ant 측 ANT_TUMBLEBUG_USERNAME/ANT_TUMBLEBUG_PASSWORD 환경변수 또는 config Tumblebug.Username/Password 확인 필요", endpoint)}
+		}
+		return DepStatus{Reachable: true, Authenticated: false, LastCheck: now,
+			Error: fmt.Sprintf("cb-tumblebug 인증 확인 호출 오류 (host=%s, GET /tumblebug/cloudInfo): %v", endpoint, err)}
+	}
+	return DepStatus{Reachable: true, Authenticated: true, LastCheck: now}
+}
+
+// getDependencyStatus returns the most recent dependency check result, running
+// a fresh probe only when the cache TTL has expired. Used by /ant/readyz.
+func (s *AntServer) getDependencyStatus(ctx context.Context) *DepResult {
+	s.depCache.mu.Lock()
+	defer s.depCache.mu.Unlock()
+
+	if s.depCache.last != nil && time.Since(s.depCache.lastSet) < depCacheTTL {
+		return s.depCache.last
+	}
+
+	s.depCache.last = s.checkDependencies(ctx)
+	s.depCache.lastSet = time.Now()
+	return s.depCache.last
+}
+
+// CheckStartupDependencies runs a fresh dependency probe (no cache) and returns
+// an aggregated error if any dependency is not fully healthy. Called from main
+// right after NewAntServer so the container exits with a clear message when a
+// dependency is missing or misconfigured, per STANDARD-READYZ §6.2.
+func (s *AntServer) CheckStartupDependencies(ctx context.Context) error {
+	res := s.checkDependencies(ctx)
+	if res.Ready {
+		// Seed the cache so the first /ant/readyz call after startup does not
+		// double-probe the dependencies that we just verified.
+		s.depCache.mu.Lock()
+		s.depCache.last = res
+		s.depCache.lastSet = time.Now()
+		s.depCache.mu.Unlock()
+		return nil
+	}
+
+	var msgs []string
+	if !res.DB.Reachable || !res.DB.Authenticated {
+		msgs = append(msgs, res.DB.Error)
+	}
+	if !res.Spider.Reachable || !res.Spider.Authenticated {
+		msgs = append(msgs, res.Spider.Error)
+	}
+	if !res.Tumblebug.Reachable || !res.Tumblebug.Authenticated {
+		msgs = append(msgs, res.Tumblebug.Error)
+	}
+	return errors.New(strings.Join(msgs, " | "))
+}

--- a/internal/app/dependency_check.go
+++ b/internal/app/dependency_check.go
@@ -81,11 +81,11 @@ func probeDB(ctx context.Context, db *gorm.DB, now time.Time) DepStatus {
 	sqlDB, err := db.DB()
 	if err != nil {
 		return DepStatus{Reachable: false, LastCheck: now,
-			Error: fmt.Sprintf("cm-ant DB handle 획득 실패: %v. Check DB driver/configuration", err)}
+			Error: fmt.Sprintf("failed to acquire cm-ant DB handle: %v. Check DB driver/configuration", err)}
 	}
 	if err := sqlDB.PingContext(ctx); err != nil {
 		return DepStatus{Reachable: false, LastCheck: now,
-			Error: fmt.Sprintf("cm-ant DB ping 실패: %v. Check ANT_DB_HOST/USER/PASSWORD/network", err)}
+			Error: fmt.Sprintf("cm-ant DB ping failed: %v. Check ANT_DB_HOST/USER/PASSWORD and network", err)}
 	}
 	// DB connectivity == authentication for DB (creds are part of the conn).
 	return DepStatus{Reachable: true, Authenticated: true, LastCheck: now}
@@ -99,15 +99,15 @@ func probeSpider(ctx context.Context, c *spider.SpiderClient, now time.Time) Dep
 	endpoint := c.Endpoint()
 	if err := c.ReadyzWithContext(ctx); err != nil {
 		return DepStatus{Reachable: false, LastCheck: now,
-			Error: fmt.Sprintf("cb-spider 미응답 (host=%s): %v. Check cb-spider 컨테이너 상태·network", endpoint, err)}
+			Error: fmt.Sprintf("cb-spider unreachable (host=%s): %v. Check cb-spider container state and network", endpoint, err)}
 	}
 	if err := c.AuthCheckWithContext(ctx); err != nil {
 		if errors.Is(err, spider.ErrUnauthorized) {
 			return DepStatus{Reachable: true, Authenticated: false, LastCheck: now,
-				Error: fmt.Sprintf("cb-spider 인증 실패 (host=%s, HTTP 401). cm-ant 측 ANT_SPIDER_USERNAME/ANT_SPIDER_PASSWORD 환경변수 또는 config Spider.Username/Password 확인 필요", endpoint)}
+				Error: fmt.Sprintf("cb-spider authentication failed (host=%s, HTTP 401). Verify ANT_SPIDER_USERNAME and ANT_SPIDER_PASSWORD env vars (or config Spider.Username/Password) on the cm-ant side", endpoint)}
 		}
 		return DepStatus{Reachable: true, Authenticated: false, LastCheck: now,
-			Error: fmt.Sprintf("cb-spider 인증 확인 호출 오류 (host=%s, GET /spider/cloudos): %v", endpoint, err)}
+			Error: fmt.Sprintf("cb-spider auth check call error (host=%s, GET /spider/cloudos): %v", endpoint, err)}
 	}
 	return DepStatus{Reachable: true, Authenticated: true, LastCheck: now}
 }
@@ -122,22 +122,22 @@ func probeTumblebug(ctx context.Context, c *tumblebug.TumblebugClient, now time.
 		switch {
 		case errors.Is(err, tumblebug.ErrNotReady):
 			return DepStatus{Reachable: false, LastCheck: now,
-				Error: fmt.Sprintf("cb-tumblebug 미응답 (host=%s): %v. Check cb-tumblebug 컨테이너 상태·network", endpoint, err)}
+				Error: fmt.Sprintf("cb-tumblebug unreachable (host=%s): %v. Check cb-tumblebug container state and network", endpoint, err)}
 		case errors.Is(err, tumblebug.ErrNotInitialized):
 			return DepStatus{Reachable: true, Authenticated: false, LastCheck: now,
-				Error: fmt.Sprintf("cb-tumblebug 초기화 미완료 (host=%s): %v. cb-tumblebug 초기화 절차 완료 필요", endpoint, err)}
+				Error: fmt.Sprintf("cb-tumblebug not initialized (host=%s): %v. Complete cb-tumblebug initialization procedure", endpoint, err)}
 		default:
 			return DepStatus{Reachable: false, LastCheck: now,
-				Error: fmt.Sprintf("cb-tumblebug 미응답 (host=%s): %v. Check cb-tumblebug 컨테이너 상태·network", endpoint, err)}
+				Error: fmt.Sprintf("cb-tumblebug unreachable (host=%s): %v. Check cb-tumblebug container state and network", endpoint, err)}
 		}
 	}
 	if err := c.AuthCheckWithContext(ctx); err != nil {
 		if errors.Is(err, tumblebug.ErrUnauthorized) {
 			return DepStatus{Reachable: true, Authenticated: false, LastCheck: now,
-				Error: fmt.Sprintf("cb-tumblebug 인증 실패 (host=%s, HTTP 401). cm-ant 측 ANT_TUMBLEBUG_USERNAME/ANT_TUMBLEBUG_PASSWORD 환경변수 또는 config Tumblebug.Username/Password 확인 필요", endpoint)}
+				Error: fmt.Sprintf("cb-tumblebug authentication failed (host=%s, HTTP 401). Verify ANT_TUMBLEBUG_USERNAME and ANT_TUMBLEBUG_PASSWORD env vars (or config Tumblebug.Username/Password) on the cm-ant side", endpoint)}
 		}
 		return DepStatus{Reachable: true, Authenticated: false, LastCheck: now,
-			Error: fmt.Sprintf("cb-tumblebug 인증 확인 호출 오류 (host=%s, GET /tumblebug/cloudInfo): %v", endpoint, err)}
+			Error: fmt.Sprintf("cb-tumblebug auth check call error (host=%s, GET /tumblebug/cloudInfo): %v", endpoint, err)}
 	}
 	return DepStatus{Reachable: true, Authenticated: true, LastCheck: now}
 }

--- a/internal/app/server.go
+++ b/internal/app/server.go
@@ -34,9 +34,19 @@ type antServices struct {
 // AntServer represents the server instance for the CM-Ant application.
 // It contains an Echo instance for handling HTTP requests
 // and multiple services for validating the core functionality of cloud migration.
+//
+// The spider/tumblebug clients and DB connection are also held directly so that
+// startup fail-fast and the /ant/readyz handler can share a single dependency
+// check function (see internal/app/dependency_check.go and STANDARD-READYZ in
+// cmig-workflow c-mig-common/design/07-DESIGN/STANDARD-READYZ.md).
 type AntServer struct {
-	e        *echo.Echo
-	services *antServices
+	e               *echo.Echo
+	services        *antServices
+	spiderClient    *spider.SpiderClient
+	tumblebugClient *tumblebug.TumblebugClient
+	db              *gorm.DB
+
+	depCache depCache
 }
 
 // NewAntServer initializes and returns a new instance of AntServer.
@@ -60,8 +70,11 @@ func NewAntServer() (*AntServer, error) {
 	services := initializeServices(repos, tumblebugClient, spiderClient, conn)
 
 	return &AntServer{
-		e:        e,
-		services: services,
+		e:               e,
+		services:        services,
+		spiderClient:    spiderClient,
+		tumblebugClient: tumblebugClient,
+		db:              conn,
 	}, nil
 }
 

--- a/internal/infra/outbound/spider/spider_client.go
+++ b/internal/infra/outbound/spider/spider_client.go
@@ -16,6 +16,7 @@ import (
 
 var (
 	ErrBadRequest          = errors.New("bad request")
+	ErrUnauthorized        = errors.New("unauthorized")
 	ErrNotFound            = errors.New("object not found")
 	ErrInternalServerError = errors.New("spider server has got error")
 )
@@ -54,6 +55,10 @@ func NewSpiderClient(client *http.Client) *SpiderClient {
 	}
 }
 
+func (s *SpiderClient) Endpoint() string {
+	return s.domain
+}
+
 func (s *SpiderClient) withUrl(endpoint string) string {
 	trimmedEndpoint := strings.TrimPrefix(endpoint, "/")
 	return fmt.Sprintf("%s/spider/%s", s.domain, trimmedEndpoint)
@@ -85,6 +90,8 @@ func (s *SpiderClient) requestWithContext(ctx context.Context, method, url strin
 
 		if resp.StatusCode == http.StatusNotFound {
 			return nil, ErrNotFound
+		} else if resp.StatusCode == http.StatusUnauthorized {
+			return nil, ErrUnauthorized
 		} else if resp.StatusCode == http.StatusInternalServerError {
 			return nil, ErrInternalServerError
 		} else if resp.StatusCode == http.StatusBadRequest {
@@ -114,9 +121,25 @@ func (s *SpiderClient) ReadyzWithContext(ctx context.Context) error {
 	_, err := s.requestWithBaseAuthWithContext(ctx, http.MethodGet, url, nil)
 
 	if err != nil {
-		log.Error().Msgf("error sending tumblebug readyz request; %v", err)
+		log.Error().Msgf("error sending cb-spider readyz request; %v", err)
 		return err
 	}
 
+	return nil
+}
+
+// AuthCheckWithContext calls a lightweight authenticated cb-spider endpoint
+// (GET /spider/cloudos) to verify Basic Auth credentials. Per STANDARD-READYZ
+// (c-mig-common/design/07-DESIGN/STANDARD-READYZ.md), the cb-spider /readyz
+// endpoint is on the auth-middleware skip list and therefore does not validate
+// credentials. /spider/cloudos is enforced and returns a small static list of
+// built-in cloud OS names, so it is unaffected by operator data.
+func (s *SpiderClient) AuthCheckWithContext(ctx context.Context) error {
+	url := s.withUrl("/cloudos")
+	_, err := s.requestWithBaseAuthWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		log.Error().Msgf("cb-spider auth check failed (GET /spider/cloudos); %v", err)
+		return err
+	}
 	return nil
 }

--- a/internal/infra/outbound/spider/spider_client_test.go
+++ b/internal/infra/outbound/spider/spider_client_test.go
@@ -1,0 +1,128 @@
+package spider
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// newTestClient constructs a SpiderClient against the given httptest server.
+// Tests in the same package can set unexported fields directly.
+//
+// withUrl uses only the domain field, so we set domain to the full httptest
+// URL (scheme included). The host/port fields mirror the parsed URL for
+// completeness and Endpoint() reporting.
+func newTestClient(t *testing.T, srv *httptest.Server) *SpiderClient {
+	t.Helper()
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("parse httptest URL: %v", err)
+	}
+	creds := base64.StdEncoding.EncodeToString([]byte("default:default"))
+	return &SpiderClient{
+		client:     srv.Client(),
+		host:       u.Hostname(),
+		port:       u.Port(),
+		username:   "default",
+		password:   "default",
+		domain:     srv.URL,
+		authHeader: "Basic " + creds,
+	}
+}
+
+// TestReadyzWithContext_OK verifies cb-spider /readyz happy path.
+func TestReadyzWithContext_OK(t *testing.T) {
+	called := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		if r.URL.Path != "/spider/readyz" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"message":"CB-Spider is ready"}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	if err := c.ReadyzWithContext(context.Background()); err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+	if !called {
+		t.Fatalf("handler not called")
+	}
+}
+
+// TestAuthCheck_OK verifies the auth-enforced GET /spider/cloudos succeeds
+// with a valid Basic Auth header.
+func TestAuthCheck_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/spider/cloudos" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if !strings.HasPrefix(r.Header.Get("Authorization"), "Basic ") {
+			t.Errorf("missing Basic Auth header")
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`["aws","azure","gcp"]`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	if err := c.AuthCheckWithContext(context.Background()); err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+}
+
+// TestAuthCheck_Unauthorized verifies 401 surfaces as ErrUnauthorized so that
+// callers can distinguish authentication failure from other errors and emit a
+// targeted operator message (per STANDARD-READYZ §6.3).
+func TestAuthCheck_Unauthorized(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"message":"Unauthorized"}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	err := c.AuthCheckWithContext(context.Background())
+	if !errors.Is(err, ErrUnauthorized) {
+		t.Fatalf("expected ErrUnauthorized, got %v", err)
+	}
+}
+
+// TestAuthCheck_InternalServerError verifies 500 maps to ErrInternalServerError.
+func TestAuthCheck_InternalServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	err := c.AuthCheckWithContext(context.Background())
+	if !errors.Is(err, ErrInternalServerError) {
+		t.Fatalf("expected ErrInternalServerError, got %v", err)
+	}
+}
+
+// TestAuthCheck_NetworkFailure verifies a closed server surfaces a non-nil
+// error (Reachable=false case in dependency_check.go).
+func TestAuthCheck_NetworkFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	srv.Close() // close immediately so requests fail
+
+	c := newTestClient(t, srv)
+	err := c.AuthCheckWithContext(context.Background())
+	if err == nil {
+		t.Fatalf("expected non-nil error on closed server")
+	}
+	if errors.Is(err, ErrUnauthorized) {
+		t.Fatalf("network failure should not surface as ErrUnauthorized: %v", err)
+	}
+}

--- a/internal/infra/outbound/tumblebug/tumblebug_client.go
+++ b/internal/infra/outbound/tumblebug/tumblebug_client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -16,7 +17,10 @@ import (
 
 var (
 	ErrBadRequest          = errors.New("bad request")
+	ErrUnauthorized        = errors.New("unauthorized")
 	ErrNotFound            = errors.New("object not found")
+	ErrNotReady            = errors.New("cb-tumblebug not ready")
+	ErrNotInitialized      = errors.New("cb-tumblebug not initialized")
 	ErrInternalServerError = errors.New("tumblebug server has got error")
 )
 
@@ -28,6 +32,16 @@ type TumblebugClient struct {
 	password   string
 	domain     string
 	authHeader string
+}
+
+// readyzResponse mirrors the relevant fields of cb-tumblebug's ReadyzResponse
+// (src/interface/rest/server/common/utility.go RestGetReadyz). cb-tumblebug
+// returns HTTP 200 even when Initialized is false (per STANDARD-READYZ pattern
+// B), so callers must inspect the body to determine actual readiness.
+type readyzResponse struct {
+	Ready       bool   `json:"ready"`
+	Initialized bool   `json:"initialized"`
+	Message     string `json:"message"`
 }
 
 func NewTumblebugClient(client *http.Client) *TumblebugClient {
@@ -47,6 +61,10 @@ func NewTumblebugClient(client *http.Client) *TumblebugClient {
 			),
 		),
 	}
+}
+
+func (t *TumblebugClient) Endpoint() string {
+	return t.domain
 }
 
 func (t *TumblebugClient) withUrl(endpoint string) string {
@@ -80,6 +98,8 @@ func (t *TumblebugClient) requestWithContext(ctx context.Context, method, url st
 
 		if resp.StatusCode == http.StatusNotFound {
 			return nil, ErrNotFound
+		} else if resp.StatusCode == http.StatusUnauthorized {
+			return nil, ErrUnauthorized
 		} else if resp.StatusCode == http.StatusInternalServerError {
 			return nil, ErrInternalServerError
 		} else if resp.StatusCode == http.StatusBadRequest {
@@ -103,15 +123,43 @@ func (t *TumblebugClient) requestWithBaseAuthWithContext(ctx context.Context, me
 	return t.requestWithContext(ctx, method, url, body, map[string]string{"Authorization": t.authHeader})
 }
 
+// ReadyzWithContext calls cb-tumblebug GET /tumblebug/readyz and inspects the
+// response body. Per STANDARD-READYZ §5, cb-tumblebug returns HTTP 200 even
+// when SystemInitialized is false, so a simple status check is insufficient.
+// We require both Ready and Initialized to be true.
 func (t *TumblebugClient) ReadyzWithContext(ctx context.Context) error {
-
 	url := t.withUrl("/readyz")
-	_, err := t.requestWithBaseAuthWithContext(ctx, http.MethodGet, url, nil)
-
+	body, err := t.requestWithBaseAuthWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
-		log.Error().Msgf("error sending tumblebug readyz request; %v", err)
+		log.Error().Msgf("error sending cb-tumblebug readyz request; %v", err)
 		return err
 	}
 
+	var rz readyzResponse
+	if uerr := json.Unmarshal(body, &rz); uerr != nil {
+		return fmt.Errorf("failed to parse cb-tumblebug readyz response: %w", uerr)
+	}
+
+	if !rz.Ready {
+		return fmt.Errorf("%w: %s", ErrNotReady, rz.Message)
+	}
+	if !rz.Initialized {
+		return fmt.Errorf("%w (Ready=true, Initialized=false): %s", ErrNotInitialized, rz.Message)
+	}
+	return nil
+}
+
+// AuthCheckWithContext calls a lightweight authenticated cb-tumblebug endpoint
+// (GET /tumblebug/cloudInfo) to verify Basic Auth credentials. Per
+// STANDARD-READYZ, /tumblebug/readyz is on the auth-middleware skip list and
+// does not validate credentials. /tumblebug/cloudInfo is enforced and returns
+// a small static cloud metadata payload that is independent of operator data.
+func (t *TumblebugClient) AuthCheckWithContext(ctx context.Context) error {
+	url := t.withUrl("/cloudInfo")
+	_, err := t.requestWithBaseAuthWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		log.Error().Msgf("cb-tumblebug auth check failed (GET /tumblebug/cloudInfo); %v", err)
+		return err
+	}
 	return nil
 }

--- a/internal/infra/outbound/tumblebug/tumblebug_client_test.go
+++ b/internal/infra/outbound/tumblebug/tumblebug_client_test.go
@@ -1,0 +1,135 @@
+package tumblebug
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// newTestClient constructs a TumblebugClient against the given httptest server.
+// withUrl uses only the domain field, so we set domain to the full httptest
+// URL (scheme included). The host/port fields mirror the parsed URL.
+func newTestClient(t *testing.T, srv *httptest.Server) *TumblebugClient {
+	t.Helper()
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("parse httptest URL: %v", err)
+	}
+	creds := base64.StdEncoding.EncodeToString([]byte("default:default"))
+	return &TumblebugClient{
+		client:     srv.Client(),
+		host:       u.Hostname(),
+		port:       u.Port(),
+		username:   "default",
+		password:   "default",
+		domain:     srv.URL,
+		authHeader: "Basic " + creds,
+	}
+}
+
+// TestReadyz_FullyReady covers the happy path: HTTP 200 + Ready=true + Initialized=true.
+func TestReadyz_FullyReady(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/tumblebug/readyz") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ready":true,"initialized":true,"message":"CB-Tumblebug is ready and initialized"}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	if err := c.ReadyzWithContext(context.Background()); err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+}
+
+// TestReadyz_NotInitialized covers the cb-tumblebug pattern B partial-failure
+// case: HTTP 200 but Initialized=false. Per STANDARD-READYZ §5/§6, this must
+// surface as a distinct error so cm-ant can mark the dependency as not fully
+// healthy even though the HTTP status was 200.
+func TestReadyz_NotInitialized(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ready":true,"initialized":false,"message":"CB-Tumblebug is ready but not initialized"}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	err := c.ReadyzWithContext(context.Background())
+	if !errors.Is(err, ErrNotInitialized) {
+		t.Fatalf("expected ErrNotInitialized, got %v", err)
+	}
+}
+
+// TestReadyz_NotReady covers HTTP 503 + Ready=false.
+func TestReadyz_NotReady(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte(`{"ready":false,"initialized":false,"message":"CB-Tumblebug is NOT ready"}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	err := c.ReadyzWithContext(context.Background())
+	// HTTP 503 maps to a generic unexpected status code error (not 401/404/500
+	// special-cased in requestWithContext). We accept any non-nil error here.
+	if err == nil {
+		t.Fatalf("expected non-nil error for 503")
+	}
+}
+
+// TestReadyz_BadJSON covers malformed body.
+func TestReadyz_BadJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`not-json`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	err := c.ReadyzWithContext(context.Background())
+	if err == nil {
+		t.Fatalf("expected parse error")
+	}
+}
+
+// TestAuthCheck_OK verifies the auth-enforced GET /tumblebug/cloudInfo path.
+func TestAuthCheck_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/tumblebug/cloudInfo") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if !strings.HasPrefix(r.Header.Get("Authorization"), "Basic ") {
+			t.Errorf("missing Basic Auth header")
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"cspNames":["aws","azure","gcp"]}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	if err := c.AuthCheckWithContext(context.Background()); err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+}
+
+// TestAuthCheck_Unauthorized verifies 401 surfaces as ErrUnauthorized.
+func TestAuthCheck_Unauthorized(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"message":"Unauthorized"}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	err := c.AuthCheckWithContext(context.Background())
+	if !errors.Is(err, ErrUnauthorized) {
+		t.Fatalf("expected ErrUnauthorized, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Tightens `/ant/readyz` so that it actually verifies whether the configured Basic Auth credentials are accepted by cb-spider and cb-tumblebug, and adds a fail-fast dependency check at container startup so cm-ant never reports healthy while every outbound call would fail with HTTP 401.

## Why

Previously `/ant/readyz` only pinged the local DB and called `/spider/readyz` and `/tumblebug/readyz` for reachability. Both upstream endpoints are on the auth-middleware skip list, so cm-ant sending an empty or wrong `Authorization` header still got HTTP 200. As a result cm-ant could keep reporting healthy for hours while the very first cost-related call to cb-spider returned 401.

In addition cb-tumblebug's `/readyz` returns HTTP 200 even when `SystemInitialized` is false, so callers that only checked the HTTP status code would silently pass an under-initialized cb-tumblebug.

## What changed

### outbound clients

- Added `ErrUnauthorized` and a 401 branch in `requestWithContext` for both `internal/infra/outbound/spider` and `internal/infra/outbound/tumblebug`.
- Added `AuthCheckWithContext()` on each client:
  - spider hits `GET /spider/cloudos` (auth-enforced, returns the built-in cloud OS list, not dependent on operator data, not used elsewhere in cm-ant)
  - tumblebug hits `GET /tumblebug/cloudInfo` (same shape on the cb-tumblebug side)
- tumblebug `ReadyzWithContext` now parses the response body and requires both `ready` and `initialized` to be true; it surfaces `ErrNotReady` and `ErrNotInitialized` accordingly.
- Exposed `Endpoint()` so the dependency check can include host information in error messages.

### app layer

- New `internal/app/dependency_check.go` runs DB ping + spider readyz + spider auth check + tumblebug readyz + tumblebug auth check in one function, with a 30 second in-memory result cache used by `/ant/readyz` (a small mutex serializes concurrent requests).
- `AntServer` now also keeps the spider/tumblebug clients and the gorm DB so the same probe function serves both the startup hook and the readyz handler.
- `cmd/cm-ant/main.go` calls `CheckStartupDependencies` right after `NewAntServer` with a 30 second timeout. On failure it logs an English message that names the failing dependency, the host, and the environment variables an operator should verify, then exits via `log.Fatal`. Combined with `restart: unless-stopped` this surfaces misconfiguration as a visible exit loop instead of a healthy but non-functional container.
- `/ant/readyz` now returns a structured body so callers can read per-dependency state in addition to the HTTP status:

```json
{
  "ready": true,
  "initialized": true,
  "message": "CM-Ant is ready",
  "dependencies": {
    "db":        {"reachable": true, "authenticated": true, "lastCheck": "..."},
    "spider":    {"reachable": true, "authenticated": true, "lastCheck": "..."},
    "tumblebug": {"reachable": true, "authenticated": true, "lastCheck": "..."}
  }
}
```

HTTP 200 only when every dependency is reachable and authenticated; HTTP 503 otherwise. Docker healthcheck flips to unhealthy automatically on 503, so no compose change is required for consumers.

### Swagger spec

The `/ant/readyz` response schema changed, so `make swag` was rerun to refresh `api/docs.go`, `api/swagger.json`, and `api/swagger.yaml`. The annotated `@version` in `cmd/cm-ant/main.go` is bumped from `0.4.0` to `0.6.0` to match the upcoming release line.

## Compatibility

- `/ant/readyz` response body shape changes from `{message}` to `{ready, initialized, message, dependencies}`. Consumers that only relied on the HTTP 200/503 status keep working. Consumers that parsed the body need to migrate.
- A container that was previously healthy but had a misconfigured `ANT_SPIDER_USERNAME/PASSWORD` or `ANT_TUMBLEBUG_USERNAME/PASSWORD` will now exit on startup until the operator fixes the env. The exit message names the variable.
- Outbound call rate to cb-spider and cb-tumblebug is bounded by the 30 second cache, so each readyz invocation adds at most two GETs per 30 seconds.

## Verification

### Unit tests (11 passed)

- `internal/infra/outbound/spider/spider_client_test.go` (5) — readyz happy path, auth check happy path, 401 -> ErrUnauthorized, 500 -> ErrInternalServerError, network failure
- `internal/infra/outbound/tumblebug/tumblebug_client_test.go` (6) — readyz fully ready, Initialized=false -> ErrNotInitialized, 503, malformed JSON, auth check happy path, 401

```
$ go test ./internal/infra/outbound/spider/... ./internal/infra/outbound/tumblebug/... -count=1
ok      github.com/cloud-barista/cm-ant/internal/infra/outbound/spider          0.008s
ok      github.com/cloud-barista/cm-ant/internal/infra/outbound/tumblebug       0.008s
```

`go build ./...` and `go vet ./...` produce no new findings.

### Integration e2e (5 scenarios passed)

Built the image locally on an Ubuntu 24.04 host and ran it inside a 22-container Cloud-Migrator lineup (cb-spider 0.12.32, cb-tumblebug 0.12.19, cm-beetle 0.5.3, cb-mapui 0.12.43, mc-terrarium 0.1.4).

| # | Scenario | Expectation | Result |
|---|---|---|:-:|
| A | Healthy startup | container healthy, readyz 200, every dependency authenticated=true | passed |
| B | cm-ant SPIDER username blanked, restart | container loops in Restarting(1), startup log explains the failing spider env vars | passed |
| C | cm-ant TUMBLEBUG password set to a wrong value, restart | same fail-fast pattern with tumblebug-side message | passed |
| D | Stop cb-spider while cm-ant is healthy | readyz 503, spider.reachable=false, diagnostic message included | passed |
| E | cb-tumblebug `DELETE /tumblebug/readyz/init` (Initialized=false) | readyz 503, tumblebug.authenticated=false (body parsing works), then readyz returns to 200 after re-init | passed |

Reproduction commands are environment-independent:

```bash
curl -sS http://<cm-ant-host>:8880/ant/readyz | jq
docker ps --format '{{.Names}}\t{{.Status}}' | grep cm-ant
docker logs cm-ant 2>&1 | grep FATAL
```