### PR TITLE
fix(load): shorten JMeter connect timeout so unreachable targets fail fast

### DIFF
--- a/internal/core/load/jmx_parser.go
+++ b/internal/core/load/jmx_parser.go
@@ -72,7 +72,7 @@ var jmxHttpSamplerTemplate = map[string]string{
 		<boolProp name="HTTPSampler.use_keepalive">true</boolProp>
 		<boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
 		<stringProp name="HTTPSampler.embedded_url_re"></stringProp>
-		<stringProp name="HTTPSampler.connect_timeout">60000</stringProp>
+		<stringProp name="HTTPSampler.connect_timeout">5000</stringProp>
 		<stringProp name="HTTPSampler.response_timeout">60000</stringProp>
 	</HTTPSamplerProxy>
 	<hashTree/>
@@ -100,7 +100,7 @@ var jmxHttpSamplerTemplate = map[string]string{
 		<boolProp name="HTTPSampler.use_keepalive">true</boolProp>
 		<boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
 		<stringProp name="HTTPSampler.embedded_url_re"></stringProp>
-		<stringProp name="HTTPSampler.connect_timeout">60000</stringProp>
+		<stringProp name="HTTPSampler.connect_timeout">5000</stringProp>
 		<stringProp name="HTTPSampler.response_timeout">60000</stringProp>
 	</HTTPSamplerProxy>
 	`,


### PR DESCRIPTION
## Summary

Shorten the JMeter HTTP sampler connect timeout so load requests to an unreachable target fail fast instead of hanging.

## Background

When the load target is not reachable at the start of a test (port closed, web server not up yet), each JMeter request hangs on the OS TCP connect backoff (observed ~2 minutes per request). As a result a short-duration test can drag on for around 10 minutes, and the result files are delayed accordingly. This is a different cause from result rsync collection latency; the sampler's default connect timeout is simply too large.

## Change

Lower `HTTPSampler.connect_timeout` from 60000ms to 5000ms in both the GET and POST sampler templates in `internal/core/load/jmx_parser.go`. `response_timeout` (60000ms) is left unchanged.

## Verification

- `go build ./...` passes.
- Requests to an unreachable target now fail within ~5s each, greatly reducing the total test time and result generation time for short tests.