### PR TITLE
feat(load): self-heal stale load generator with configurable recovery

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -29,6 +29,14 @@ load:
     mci: "ant-default-mci"         # MCI 이름
     vm: "ant-default-vm"           # VM 이름
     sshKey: "ant-default-shared"   # SSH 키 이름 (접미사는 자동 추가)
+  # 부하 발생기 자가 복구 정책 (FR-MA2-PERF-007-09)
+  generator:
+    # 재사용하려던 발생기가 사용 불가(외부 삭제·재시도 후에도 접속 불가)일 때 동작
+    #   auto       : stale 발생기를 강제 정리(terminate+강제삭제) 후 재생성 (기본, 서비스 자동 유지)
+    #   manual     : 삭제하지 않고 test_failed + 진단 메시지로 관리자 조치 유도
+    #   newInstall : 기존 MCI는 고아로 남기고 새 이름(ant-default-mci-01/-02...)으로 새로 설치.
+    #                접미사는 DB에 저장되어 다음 실행에 이어짐. 고아 MCI/VM은 관리자가 정리(비용 주의).
+    recovery: "auto"
   jmeter:
     dir: "/opt/ant/jmeter"
     version: 5.6

--- a/config.yaml
+++ b/config.yaml
@@ -29,13 +29,13 @@ load:
     mci: "ant-default-mci"         # MCI 이름
     vm: "ant-default-vm"           # VM 이름
     sshKey: "ant-default-shared"   # SSH 키 이름 (접미사는 자동 추가)
-  # 부하 발생기 자가 복구 정책 (FR-MA2-PERF-007-09)
+  # Load generator self-heal policy (FR-MA2-PERF-007-09)
   generator:
-    # 재사용하려던 발생기가 사용 불가(외부 삭제·재시도 후에도 접속 불가)일 때 동작
-    #   auto       : stale 발생기를 강제 정리(terminate+강제삭제) 후 재생성 (기본, 서비스 자동 유지)
-    #   manual     : 삭제하지 않고 test_failed + 진단 메시지로 관리자 조치 유도
-    #   newInstall : 기존 MCI는 고아로 남기고 새 이름(ant-default-mci-01/-02...)으로 새로 설치.
-    #                접미사는 DB에 저장되어 다음 실행에 이어짐. 고아 MCI/VM은 관리자가 정리(비용 주의).
+    # What to do when a reused generator is unusable (deleted externally, or unreachable after retries)
+    #   auto       : force-clean the stale generator (terminate+delete) and recreate it (default; keeps the service self-healing)
+    #   manual     : do not delete; fail the test with a diagnostic message so an operator can act
+    #   newInstall : leave the old MCI orphaned and install a fresh one under a rotated name (ant-default-mci-01/-02...).
+    #                the suffix is persisted in the DB and carries over to the next run; the operator cleans up orphan MCIs/VMs (mind the cost).
     recovery: "auto"
   jmeter:
     dir: "/opt/ant/jmeter"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -52,6 +52,16 @@ type AntConfig struct {
 			Vm        string `yaml:"vm"`
 			SshKey    string `yaml:"sshKey"`
 		} `yaml:"defaultResourceName"`
+		Generator struct {
+			// Recovery controls what happens when a reused load generator turns out to be
+			// unusable (VM deleted externally, or unreachable after retries):
+			//   "auto"       - force-reset the stale generator and recreate it (default)
+			//   "manual"     - stop with test_failed and a diagnostic message; operator fixes it
+			//   "newInstall" - leave the old MCI orphaned, install a fresh one under a rotated
+			//                  name (base-01/-02/...); the suffix is persisted in the DB.
+			// FR-MA2-PERF-007-09.
+			Recovery string `yaml:"recovery"`
+		} `yaml:"generator"`
 		JMeter struct {
 			Dir     string `yaml:"dir"`
 			Version string `yaml:"version"`

--- a/internal/core/load/load_generator_install_service.go
+++ b/internal/core/load/load_generator_install_service.go
@@ -34,6 +34,11 @@ const (
 	antPrivKeyName = "id_rsa_ant"
 
 	defaultDelay = 20 * time.Second
+
+	// FR-MA2-PERF-007-09 generator recovery modes (config load.generator.recovery)
+	recoveryAuto       = "auto"       // force-reset stale generator and recreate (default)
+	recoveryManual     = "manual"     // stop with a diagnostic message, no delete
+	recoveryNewInstall = "newinstall" // leave the old MCI orphaned, install a new base-NN one
 )
 
 // InstallLoadGenerator installs the load generator either locally or remotely.
@@ -167,61 +172,138 @@ func (l *LoadService) InstallLoadGenerator(param InstallLoadGeneratorParam) (Loa
 			return result, err
 		}
 
-		// get the ant default mci
-		antMci, err := l.getAndDefaultMci(ctx, antVmCommonSpec, antVmCommonImage, existingConnectionName)
-		if err != nil {
-			log.Error().Msgf("Error getting or creating default mci; %v", err)
-			return result, err
+		// FR-MA2-PERF-007-09: reuse the generator, self-healing a stale record.
+		//
+		// When the saved generator VM was deleted externally, cb-tumblebug keeps a stale
+		// "Running" status in its cache (a GET does not trigger a live CSP poll) and the
+		// `reconcile` action only touches transient nodes, so a status-based pre-check is
+		// unreliable. Instead we treat a failure of the reuse/prepare operations as the
+		// signal. The remote install command is retried first (SSH/command flakes are common
+		// on small VMs) to tell a transient failure apart from a truly missing VM; only after
+		// the retries are exhausted do we act on config load.generator.recovery:
+		//   auto       - force-reset the ant MCI (terminate + option=terminate delete, which
+		//                succeed even when the CSP VM is gone) and recreate it, once.
+		//   manual     - stop with a diagnostic message so the operator can inspect/fix the VM.
+		//   newInstall - leave the (assumed broken) MCI orphaned and install a fresh one under a
+		//                rotated name (base-01/-02/...); the operator cleans up the orphan later.
+		recovery := strings.ToLower(strings.TrimSpace(config.AppConfig.Load.Generator.Recovery))
+		if recovery == "" {
+			recovery = recoveryAuto
+		}
+		maxAttempts := 1
+		if recovery == recoveryAuto || recovery == recoveryNewInstall {
+			maxAttempts = 2
 		}
 
-		// if server is not running state, try to resume and get mci information
-		retryCount := config.AppConfig.Load.Retry
-		for retryCount > 0 && antMci.StatusCount.CountRunning < 1 {
-			log.Info().Msgf("Attempting to resume MCI, retry count: %d", retryCount)
+		// Active generator MCI name: the config base name, or a rotated base-NN persisted by a
+		// prior newInstall recovery (FR-MA2-PERF-007-09).
+		_, baseMci, baseVm, _ := getResourceNames()
+		activeMci := loadGeneratorInstallInfo.MciName
+		if activeMci == "" {
+			activeMci = baseMci
+		}
 
-			err = l.tumblebugClient.ControlLifecycleWithContext(ctx, nsId, antMci.Id, "resume")
+		var antMci tumblebug.MciRes
+		for attempt := 1; attempt <= maxAttempts; attempt++ {
+			antMci, err = l.getAndDefaultMci(ctx, antVmCommonSpec, antVmCommonImage, existingConnectionName, activeMci, baseVm)
 			if err != nil {
-				log.Error().Msgf("Error resuming MCI; %v", err)
+				log.Error().Msgf("Error getting or creating default mci; %v", err)
 				return result, err
 			}
-			time.Sleep(defaultDelay)
-			antMci, err = l.getAndDefaultMci(ctx, antVmCommonSpec, antVmCommonImage, existingConnectionName)
-			if err != nil {
-				log.Error().Msgf("Error getting MCI after resume attempt; %v", err)
-				return result, err
+
+			// if server is not running state, try to resume and get mci information
+			retryCount := config.AppConfig.Load.Retry
+			var prepareErr error
+			for retryCount > 0 && antMci.StatusCount.CountRunning < 1 {
+				log.Info().Msgf("Attempting to resume MCI, retry count: %d", retryCount)
+
+				prepareErr = l.tumblebugClient.ControlLifecycleWithContext(ctx, nsId, antMci.Id, "resume")
+				if prepareErr != nil {
+					log.Error().Msgf("Error resuming MCI; %v", prepareErr)
+					break
+				}
+				time.Sleep(defaultDelay)
+				antMci, err = l.getAndDefaultMci(ctx, antVmCommonSpec, antVmCommonImage, existingConnectionName, activeMci, baseVm)
+				if err != nil {
+					log.Error().Msgf("Error getting MCI after resume attempt; %v", err)
+					return result, err
+				}
+
+				retryCount = retryCount - 1
 			}
 
-			retryCount = retryCount - 1
-		}
+			if prepareErr == nil && antMci.StatusCount.CountRunning < 1 {
+				prepareErr = errors.New("발생기 VM이 실행 상태가 아님 (외부 삭제 추정)")
+			}
 
-		if antMci.StatusCount.CountRunning < 1 {
-			log.Error().Msg("No running VM on ant default MCI")
-			return result, errors.New("there is no running vm on ant default mci")
-		}
+			// Remote install command — reads (key + script) are hard errors (not a recovery
+			// case), the command send itself is retried to absorb transient SSH/command flakes.
+			if prepareErr == nil {
+				addAuthorizedKeyCommand, kerr := getAddAuthorizedKeyCommand(antPrivKeyName, antPubKeyName)
+				if kerr != nil {
+					log.Error().Msgf("Error getting add authorized key command; %v", kerr)
+					return result, kerr
+				}
+				installationCommand, rerr := utils.ReadToString(installScriptPath)
+				if rerr != nil {
+					log.Error().Msgf("Error reading installation script; %v", rerr)
+					return result, rerr
+				}
+				commandReq := tumblebug.SendCommandReq{
+					Command: []string{installationCommand, addAuthorizedKeyCommand},
+				}
 
-		addAuthorizedKeyCommand, err := getAddAuthorizedKeyCommand(antPrivKeyName, antPubKeyName)
-		if err != nil {
-			log.Error().Msgf("Error getting add authorized key command; %v", err)
-			return result, err
-		}
+				cmdRetries := config.AppConfig.Load.Retry
+				if cmdRetries < 1 {
+					cmdRetries = 1
+				}
+				for k := 1; k <= cmdRetries; k++ {
+					if k == 1 {
+						log.Info().Msg("JMeter 설치 중")
+					} else {
+						log.Info().Msgf("JMeter 설치 중 (재시도%d)", k-1)
+						time.Sleep(defaultDelay)
+					}
+					_, prepareErr = l.tumblebugClient.CommandToMciWithContext(ctx, nsId, antMci.Id, commandReq)
+					if prepareErr == nil {
+						break
+					}
+					log.Warn().Msgf("Remote install command failed (%d/%d); %v", k, cmdRetries, prepareErr)
+				}
+			}
 
-		installationCommand, err := utils.ReadToString(installScriptPath)
-		if err != nil {
-			log.Error().Msgf("Error reading installation script; %v", err)
-			return result, err
-		}
+			if prepareErr == nil {
+				log.Info().Msg("Commands sent to MCI successfully")
+				break
+			}
 
-		commandReq := tumblebug.SendCommandReq{
-			Command: []string{installationCommand, addAuthorizedKeyCommand},
-		}
+			// Generator unusable after retries → act on the configured recovery policy.
+			if attempt < maxAttempts {
+				switch recovery {
+				case recoveryAuto:
+					log.Warn().Msgf("Generator unusable (recovery=auto); force-resetting %q and recreating; %v", activeMci, prepareErr)
+					l.forceResetLoadGenerator(ctx, nsId, activeMci)
+					continue
+				case recoveryNewInstall:
+					newMci := nextGeneratorMciName(activeMci, baseMci)
+					log.Warn().Msgf("Generator unusable (recovery=newInstall); leaving old MCI %q orphaned, installing new %q; %v", activeMci, newMci, prepareErr)
+					activeMci = newMci
+					loadGeneratorInstallInfo.MciName = newMci
+					loadGeneratorInstallInfo.LoadGeneratorServers = nil
+					if uerr := l.loadRepo.UpdateLoadGeneratorInstallInfoTx(ctx, loadGeneratorInstallInfo); uerr != nil {
+						log.Warn().Msgf("newInstall: failed to persist rotated MCI name %q; %v", newMci, uerr)
+					}
+					continue
+				}
+			}
 
-		_, err = l.tumblebugClient.CommandToMciWithContext(ctx, nsId, antMci.Id, commandReq)
-		if err != nil {
-			log.Error().Msgf("Error sending command to MCI; %v", err)
-			return result, err
+			if recovery == recoveryManual {
+				return result, fmt.Errorf(
+					"발생기 준비 실패 (recovery=manual 이므로 자동 삭제/재생성하지 않음). 발생기 VM(%s/%s)이 tumblebug에는 존재하나 실제로는 접속/원격명령이 안 될 수 있습니다. 실제 VM 상태를 확인·조치(또는 tumblebug 강제삭제) 후 재시도하거나 recovery=auto 를 사용하세요. 원인: %w",
+					nsId, antMci.Id, prepareErr)
+			}
+			return result, fmt.Errorf("발생기 준비 실패 (자동 복구(%s) 후에도 복구되지 않음). 실제 VM 상태 확인이 필요합니다. 원인: %w", recovery, prepareErr)
 		}
-
-		log.Info().Msg("Commands sent to MCI successfully")
 
 		marking := make(map[string]LoadGeneratorServer)
 		deleteChecker := make(map[uint]bool)
@@ -366,11 +448,52 @@ func (l *LoadService) InstallLoadGenerator(param InstallLoadGeneratorParam) (Loa
 	return result, nil
 }
 
-// getAndDefaultMci retrieves or creates the default MCI.
-func (l *LoadService) getAndDefaultMci(ctx context.Context, antVmCommonSpec, antVmCommonImage, antVmConnectionName string) (tumblebug.MciRes, error) {
+// forceResetLoadGenerator purges a stale ant-default MCI so the next getAndDefaultMci
+// recreates it from scratch (FR-MA2-PERF-007-09 self-heal).
+//
+// It is status-agnostic on purpose: when the generator VM was deleted externally,
+// cb-tumblebug still reports it as "Running" from cache, so `reconcile`/`refine` leave
+// the ghost node in place. `action=terminate` followed by DELETE .../infra?option=terminate
+// both return 200 even when the CSP VM is already gone and remove the MCI record
+// completely. The ant namespace holds only the generator MCI, so this never touches the
+// user's target VMs. The stale LoadGeneratorServer rows are reconciled by the normal
+// rebuild loop once the fresh MCI is created, so no explicit DB cleanup is needed here.
+//
+// Best-effort: errors are logged but not returned, because the recreate on the next
+// attempt is what actually determines success or failure.
+func (l *LoadService) forceResetLoadGenerator(ctx context.Context, nsId, mciId string) {
+	if err := l.tumblebugClient.ControlLifecycleWithContext(ctx, nsId, mciId, "terminate"); err != nil {
+		log.Warn().Msgf("force-reset: terminate returned error (continuing to delete); %v", err)
+	}
+	time.Sleep(defaultDelay)
+
+	// The ant namespace is dedicated to the generator, so delete-all purges the stale MCI
+	// (and any orphans left by a prior newInstall) without touching user resources.
+	if err := l.tumblebugClient.DeleteAllMciWithContext(ctx, nsId, "terminate"); err != nil {
+		log.Warn().Msgf("force-reset: delete-all-mci returned error; %v", err)
+	}
+}
+
+// nextGeneratorMciName rotates the generator MCI name for the newInstall recovery mode:
+// base -> base-01 -> base-02 ... (FR-MA2-PERF-007-09). current may be the base name or an
+// already-rotated base-NN.
+func nextGeneratorMciName(current, base string) string {
+	n := 0
+	if strings.HasPrefix(current, base+"-") {
+		if v, err := strconv.Atoi(strings.TrimPrefix(current, base+"-")); err == nil {
+			n = v
+		}
+	}
+	return fmt.Sprintf("%s-%02d", base, n+1)
+}
+
+// getAndDefaultMci retrieves or creates the generator MCI named mciId (with VM vmName).
+// mciId/vmName let the caller target a rotated name for the newInstall recovery mode
+// (FR-MA2-PERF-007-09); pass the config base names for the default generator.
+func (l *LoadService) getAndDefaultMci(ctx context.Context, antVmCommonSpec, antVmCommonImage, antVmConnectionName, mciId, vmName string) (tumblebug.MciRes, error) {
 	var antMci tumblebug.MciRes
 	var err error
-	nsId, mciId, vmName, _ := getResourceNames()
+	nsId, _, _, _ := getResourceNames()
 	antMci, err = l.tumblebugClient.GetMciWithContext(ctx, nsId, mciId)
 	if err != nil {
 		if errors.Is(err, tumblebug.ErrNotFound) {
@@ -938,7 +1061,11 @@ func (l *LoadService) UninstallLoadGenerator(param UninstallLoadGeneratorParam) 
 			Command: []string{uninstallCommand},
 		}
 
-		nsId, mciId, _, _ := getResourceNames()
+		nsId, baseMci, _, _ := getResourceNames()
+		mciId := loadGeneratorInstallInfo.MciName
+		if mciId == "" {
+			mciId = baseMci
+		}
 		_, err = l.tumblebugClient.CommandToMciWithContext(ctx, nsId, mciId, commandReq)
 		if err != nil {
 			if errors.Is(err, context.DeadlineExceeded) {

--- a/internal/core/load/load_generator_install_service.go
+++ b/internal/core/load/load_generator_install_service.go
@@ -233,7 +233,7 @@ func (l *LoadService) InstallLoadGenerator(param InstallLoadGeneratorParam) (Loa
 			}
 
 			if prepareErr == nil && antMci.StatusCount.CountRunning < 1 {
-				prepareErr = errors.New("발생기 VM이 실행 상태가 아님 (외부 삭제 추정)")
+				prepareErr = errors.New("generator VM is not in a running state (likely deleted externally)")
 			}
 
 			// Remote install command — reads (key + script) are hard errors (not a recovery
@@ -259,9 +259,9 @@ func (l *LoadService) InstallLoadGenerator(param InstallLoadGeneratorParam) (Loa
 				}
 				for k := 1; k <= cmdRetries; k++ {
 					if k == 1 {
-						log.Info().Msg("JMeter 설치 중")
+						log.Info().Msg("Installing JMeter")
 					} else {
-						log.Info().Msgf("JMeter 설치 중 (재시도%d)", k-1)
+						log.Info().Msgf("Installing JMeter (retry %d)", k-1)
 						time.Sleep(defaultDelay)
 					}
 					_, prepareErr = l.tumblebugClient.CommandToMciWithContext(ctx, nsId, antMci.Id, commandReq)
@@ -299,10 +299,10 @@ func (l *LoadService) InstallLoadGenerator(param InstallLoadGeneratorParam) (Loa
 
 			if recovery == recoveryManual {
 				return result, fmt.Errorf(
-					"발생기 준비 실패 (recovery=manual 이므로 자동 삭제/재생성하지 않음). 발생기 VM(%s/%s)이 tumblebug에는 존재하나 실제로는 접속/원격명령이 안 될 수 있습니다. 실제 VM 상태를 확인·조치(또는 tumblebug 강제삭제) 후 재시도하거나 recovery=auto 를 사용하세요. 원인: %w",
+					"generator preparation failed (recovery=manual, so it is not deleted/recreated automatically). The generator VM (%s/%s) exists in tumblebug but may be unreachable for SSH/remote commands. Check and fix the actual VM state (or force-delete it in tumblebug) and retry, or use recovery=auto. cause: %w",
 					nsId, antMci.Id, prepareErr)
 			}
-			return result, fmt.Errorf("발생기 준비 실패 (자동 복구(%s) 후에도 복구되지 않음). 실제 VM 상태 확인이 필요합니다. 원인: %w", recovery, prepareErr)
+			return result, fmt.Errorf("generator preparation failed (still unrecoverable after automatic recovery (%s)). The actual VM state needs checking. cause: %w", recovery, prepareErr)
 		}
 
 		marking := make(map[string]LoadGeneratorServer)

--- a/internal/core/load/models.go
+++ b/internal/core/load/models.go
@@ -58,6 +58,12 @@ type LoadGeneratorInstallInfo struct {
 	InstallVersion  string
 	Status          string
 
+	// MciName is the actual cb-tumblebug MCI name backing this generator.
+	// Empty means the config base name (load.defaultResourceName.mci). It is rotated to
+	// base-01/-02/... by the newInstall recovery mode (FR-MA2-PERF-007-09), which leaves the
+	// old MCI orphaned for the operator to clean up instead of deleting it.
+	MciName string
+
 	IsCluster   bool
 	MasterId    uint
 	ClusterSize uint64

--- a/internal/infra/outbound/tumblebug/mci.go
+++ b/internal/infra/outbound/tumblebug/mci.go
@@ -393,9 +393,16 @@ func (t *TumblebugClient) ControlLifecycleWithContext(ctx context.Context, nsId,
 // DeleteAllMciWithContext call tumblebug's api which delete all mci in ns.
 // This should call after all the vm's in mci is the status of terminate or suspend.
 // If you want to change mci's vm lifecycle use ControlLifecycleWithContext.
-func (t *TumblebugClient) DeleteAllMciWithContext(ctx context.Context, nsId string) error {
+//
+// option is passed as the tumblebug `option` query parameter. Use "terminate" or
+// "force" to purge an MCI whose backing CSP resources are already gone (both return
+// 200 even when the VM no longer exists); pass "" for the default behaviour.
+func (t *TumblebugClient) DeleteAllMciWithContext(ctx context.Context, nsId, option string) error {
 	// cb-tumblebug v0.12.7 BREAKING: /mci → /infra
 	url := t.withUrl(fmt.Sprintf("/ns/%s/infra", nsId))
+	if option != "" {
+		url = fmt.Sprintf("%s?option=%s", url, option)
+	}
 
 	_, err := t.requestWithBaseAuthWithContext(ctx, http.MethodDelete, url, nil)
 


### PR DESCRIPTION
## What

Reusing a load generator whose backing VM was deleted externally no longer fails the load test.

## Why

The load generator VM is created once and reused across load tests. When that VM is deleted out-of-band (cost cleanup, manual removal, etc.), cb-tumblebug keeps a stale `Running` status in its cache for a while (a GET does not trigger a live CSP poll), and the `reconcile` action only touches transient nodes — so a status-based pre-check cannot reliably tell the VM is gone. The reuse then fails and the whole load test ends in `test_failed`, with the stale record left behind.

## How

Instead of trusting the cached status, treat a failure of the reuse/preparation operations as the signal. The remote install command is retried first (SSH/command flakes are common on small VMs) to distinguish a transient failure from a truly missing VM. Once the retries are exhausted, recovery follows the `load.generator.recovery` config:

- `auto` (default): force-reset the stale MCI (`terminate` + `DELETE .../infra?option=terminate`, which succeed even when the CSP VM is already gone) and recreate it, retrying once.
- `manual`: stop with a diagnostic message so the operator can inspect/fix the VM.
- `newInstall`: leave the old MCI orphaned and install a fresh one under a rotated name (`base-01`, `base-02`, …); the suffix is persisted on the install record.

Also adds an `option` parameter to `DeleteAllMciWithContext` so an MCI can be purged even when the CSP VM no longer exists.

## Result

After the generator VM is removed externally, the next load test automatically cleans up and recreates the generator and runs to completion — the `InvalidInstanceID.NotFound`-driven `test_failed` no longer recurs. Verified end-to-end against a development environment (cb-tumblebug 0.12.22): deleting the generator VM, then re-running, triggers the resume retries → force-reset → recreate path and the test succeeds. `go build` / `go vet` / package tests pass.