### PR TITLE
feat(load): expose per-step load test execution status (steps[])

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -2222,6 +2222,23 @@ const docTemplate = `{
                 "TestFailed"
             ]
         },
+        "constant.ExecutionStep": {
+            "type": "string",
+            "enum": [
+                "generator_install",
+                "agent_install",
+                "jmx_prepare",
+                "jmeter_run",
+                "result_fetch"
+            ],
+            "x-enum-varnames": [
+                "StepGeneratorInstall",
+                "StepAgentInstall",
+                "StepJmxPrepare",
+                "StepJmeterRun",
+                "StepResultFetch"
+            ]
+        },
         "constant.IconCode": {
             "type": "string",
             "enum": [
@@ -2290,6 +2307,23 @@ const docTemplate = `{
                 "VNet",
                 "DataDisk",
                 "Etc"
+            ]
+        },
+        "constant.StepStatus": {
+            "type": "string",
+            "enum": [
+                "pending",
+                "running",
+                "ok",
+                "failed",
+                "skipped"
+            ],
+            "x-enum-varnames": [
+                "StepPending",
+                "StepRunning",
+                "StepOk",
+                "StepFailed",
+                "StepSkipped"
             ]
         },
         "cost.EsimateCostSpecResults": {
@@ -2833,11 +2867,47 @@ const docTemplate = `{
                 "startAt": {
                     "type": "string"
                 },
+                "steps": {
+                    "description": "Steps is the per-stage progress of the run (FR-MA2-PERF-007-08), ordered by seq.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/load.LoadTestExecutionStepResult"
+                    }
+                },
                 "totalExpectedExecutionSecond": {
                     "type": "integer"
                 },
                 "updatedAt": {
                     "type": "string"
+                }
+            }
+        },
+        "load.LoadTestExecutionStepResult": {
+            "type": "object",
+            "properties": {
+                "attempt": {
+                    "type": "integer"
+                },
+                "detail": {
+                    "type": "string"
+                },
+                "finishAt": {
+                    "type": "string"
+                },
+                "message": {
+                    "type": "string"
+                },
+                "name": {
+                    "$ref": "#/definitions/constant.ExecutionStep"
+                },
+                "seq": {
+                    "type": "integer"
+                },
+                "startAt": {
+                    "type": "string"
+                },
+                "status": {
+                    "$ref": "#/definitions/constant.StepStatus"
                 }
             }
         },

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -2215,6 +2215,23 @@
                 "TestFailed"
             ]
         },
+        "constant.ExecutionStep": {
+            "type": "string",
+            "enum": [
+                "generator_install",
+                "agent_install",
+                "jmx_prepare",
+                "jmeter_run",
+                "result_fetch"
+            ],
+            "x-enum-varnames": [
+                "StepGeneratorInstall",
+                "StepAgentInstall",
+                "StepJmxPrepare",
+                "StepJmeterRun",
+                "StepResultFetch"
+            ]
+        },
         "constant.IconCode": {
             "type": "string",
             "enum": [
@@ -2283,6 +2300,23 @@
                 "VNet",
                 "DataDisk",
                 "Etc"
+            ]
+        },
+        "constant.StepStatus": {
+            "type": "string",
+            "enum": [
+                "pending",
+                "running",
+                "ok",
+                "failed",
+                "skipped"
+            ],
+            "x-enum-varnames": [
+                "StepPending",
+                "StepRunning",
+                "StepOk",
+                "StepFailed",
+                "StepSkipped"
             ]
         },
         "cost.EsimateCostSpecResults": {
@@ -2826,11 +2860,47 @@
                 "startAt": {
                     "type": "string"
                 },
+                "steps": {
+                    "description": "Steps is the per-stage progress of the run (FR-MA2-PERF-007-08), ordered by seq.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/load.LoadTestExecutionStepResult"
+                    }
+                },
                 "totalExpectedExecutionSecond": {
                     "type": "integer"
                 },
                 "updatedAt": {
                     "type": "string"
+                }
+            }
+        },
+        "load.LoadTestExecutionStepResult": {
+            "type": "object",
+            "properties": {
+                "attempt": {
+                    "type": "integer"
+                },
+                "detail": {
+                    "type": "string"
+                },
+                "finishAt": {
+                    "type": "string"
+                },
+                "message": {
+                    "type": "string"
+                },
+                "name": {
+                    "$ref": "#/definitions/constant.ExecutionStep"
+                },
+                "seq": {
+                    "type": "integer"
+                },
+                "startAt": {
+                    "type": "string"
+                },
+                "status": {
+                    "$ref": "#/definitions/constant.StepStatus"
                 }
             }
         },

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -424,6 +424,20 @@ definitions:
     - OnFetching
     - Successed
     - TestFailed
+  constant.ExecutionStep:
+    enum:
+    - generator_install
+    - agent_install
+    - jmx_prepare
+    - jmeter_run
+    - result_fetch
+    type: string
+    x-enum-varnames:
+    - StepGeneratorInstall
+    - StepAgentInstall
+    - StepJmxPrepare
+    - StepJmeterRun
+    - StepResultFetch
   constant.IconCode:
     enum:
     - IC0001
@@ -476,6 +490,20 @@ definitions:
     - VNet
     - DataDisk
     - Etc
+  constant.StepStatus:
+    enum:
+    - pending
+    - running
+    - ok
+    - failed
+    - skipped
+    type: string
+    x-enum-varnames:
+    - StepPending
+    - StepRunning
+    - StepOk
+    - StepFailed
+    - StepSkipped
   cost.EsimateCostSpecResults:
     properties:
       estimateForecastCostSpecDetailResults:
@@ -834,10 +862,35 @@ definitions:
         type: string
       startAt:
         type: string
+      steps:
+        description: Steps is the per-stage progress of the run (FR-MA2-PERF-007-08),
+          ordered by seq.
+        items:
+          $ref: '#/definitions/load.LoadTestExecutionStepResult'
+        type: array
       totalExpectedExecutionSecond:
         type: integer
       updatedAt:
         type: string
+    type: object
+  load.LoadTestExecutionStepResult:
+    properties:
+      attempt:
+        type: integer
+      detail:
+        type: string
+      finishAt:
+        type: string
+      message:
+        type: string
+      name:
+        $ref: '#/definitions/constant.ExecutionStep'
+      seq:
+        type: integer
+      startAt:
+        type: string
+      status:
+        $ref: '#/definitions/constant.StepStatus'
     type: object
   load.LoadTestScenarioCatalogResult:
     properties:

--- a/internal/core/common/constant/constant.go
+++ b/internal/core/common/constant/constant.go
@@ -22,6 +22,28 @@ const (
 	TestFailed   ExecutionStatus = "test_failed"
 )
 
+// ExecutionStep identifies a stage of a load test run (FR-MA2-PERF-007-08).
+type ExecutionStep string
+
+const (
+	StepGeneratorInstall ExecutionStep = "generator_install"
+	StepAgentInstall     ExecutionStep = "agent_install"
+	StepJmxPrepare       ExecutionStep = "jmx_prepare"
+	StepJmeterRun        ExecutionStep = "jmeter_run"
+	StepResultFetch      ExecutionStep = "result_fetch"
+)
+
+// StepStatus is the per-step lifecycle status (FR-MA2-PERF-007-08).
+type StepStatus string
+
+const (
+	StepPending StepStatus = "pending"
+	StepRunning StepStatus = "running"
+	StepOk      StepStatus = "ok"
+	StepFailed  StepStatus = "failed"
+	StepSkipped StepStatus = "skipped"
+)
+
 type ResultFormat string
 
 const (

--- a/internal/core/load/dtos.go
+++ b/internal/core/load/dtos.go
@@ -161,6 +161,22 @@ type LoadTestExecutionStateResult struct {
 	ExecutionDuration           string                         `json:"executionDuration,omitempty"`
 	CreatedAt                   time.Time                      `json:"createdAt,omitempty"`
 	UpdatedAt                   time.Time                      `json:"updatedAt,omitempty"`
+	// Steps is the per-stage progress of the run (FR-MA2-PERF-007-08), ordered by seq.
+	Steps []LoadTestExecutionStepResult `json:"steps,omitempty"`
+}
+
+// LoadTestExecutionStepResult exposes one execution stage for the web console
+// (FR-MA2-PERF-007-08). message is a short current-status line, detail is the verbose
+// diagnosis/error cause, attempt is the retry count (0 = first try).
+type LoadTestExecutionStepResult struct {
+	Seq      int                    `json:"seq"`
+	Name     constant.ExecutionStep `json:"name"`
+	Status   constant.StepStatus    `json:"status"`
+	Attempt  int                    `json:"attempt,omitempty"`
+	StartAt  *time.Time             `json:"startAt,omitempty"`
+	FinishAt *time.Time             `json:"finishAt,omitempty"`
+	Message  string                 `json:"message,omitempty"`
+	Detail   string                 `json:"detail,omitempty"`
 }
 
 type GetLoadTestExecutionStateParam struct {

--- a/internal/core/load/load_generator_install_service.go
+++ b/internal/core/load/load_generator_install_service.go
@@ -41,10 +41,24 @@ const (
 	recoveryNewInstall = "newinstall" // leave the old MCI orphaned, install a new base-NN one
 )
 
+// InstallProgressFn receives generator install progress so callers (e.g. a load test run)
+// can surface it as per-step status (FR-MA2-PERF-007-08). attempt is the retry count
+// (0 = first try), message is a short line, detail is a verbose diagnosis.
+type InstallProgressFn func(attempt int, message, detail string)
+
 // InstallLoadGenerator installs the load generator either locally or remotely.
 // Currently remote request is executing via cb-tumblebug.
-func (l *LoadService) InstallLoadGenerator(param InstallLoadGeneratorParam) (LoadGeneratorInstallInfoResult, error) {
+// The optional progress callback (FR-MA2-PERF-007-08) is invoked during retries/recovery.
+func (l *LoadService) InstallLoadGenerator(param InstallLoadGeneratorParam, progress ...InstallProgressFn) (LoadGeneratorInstallInfoResult, error) {
 	log.Info().Msg("Starting InstallLoadGenerator")
+
+	notify := func(attempt int, message, detail string) {
+		for _, p := range progress {
+			if p != nil {
+				p(attempt, message, detail)
+			}
+		}
+	}
 
 	// config.yaml의 commandExecution 타임아웃 설정 사용
 	timeout, err := time.ParseDuration(config.AppConfig.Load.Timeout.CommandExecution)
@@ -260,8 +274,11 @@ func (l *LoadService) InstallLoadGenerator(param InstallLoadGeneratorParam) (Loa
 				for k := 1; k <= cmdRetries; k++ {
 					if k == 1 {
 						log.Info().Msg("Installing JMeter")
+						notify(0, "Installing JMeter", "")
 					} else {
 						log.Info().Msgf("Installing JMeter (retry %d)", k-1)
+						notify(k-1, fmt.Sprintf("Installing JMeter (retry %d)", k-1),
+							fmt.Sprintf("SSH/remote command to the generator VM (%s) failed; retrying. The instance may be under-sized or the VM may no longer exist.", antMci.Id))
 						time.Sleep(defaultDelay)
 					}
 					_, prepareErr = l.tumblebugClient.CommandToMciWithContext(ctx, nsId, antMci.Id, commandReq)
@@ -282,6 +299,7 @@ func (l *LoadService) InstallLoadGenerator(param InstallLoadGeneratorParam) (Loa
 				switch recovery {
 				case recoveryAuto:
 					log.Warn().Msgf("Generator unusable (recovery=auto); force-resetting %q and recreating; %v", activeMci, prepareErr)
+					notify(0, "Recreating generator", fmt.Sprintf("the existing generator (%s) is unusable; cleaning it up and recreating (self-heal). cause: %v", activeMci, prepareErr))
 					l.forceResetLoadGenerator(ctx, nsId, activeMci)
 					continue
 				case recoveryNewInstall:

--- a/internal/core/load/load_test_execution_service.go
+++ b/internal/core/load/load_test_execution_service.go
@@ -26,6 +26,72 @@ func getResourceNames() (nsId, mciId, vmName, sshKeyBase string) {
 	return
 }
 
+// stepSeq fixes the display order of the execution steps (FR-MA2-PERF-007-08).
+var stepSeq = map[constant.ExecutionStep]int{
+	constant.StepGeneratorInstall: 1,
+	constant.StepAgentInstall:     2,
+	constant.StepJmxPrepare:       3,
+	constant.StepJmeterRun:        4,
+	constant.StepResultFetch:      5,
+}
+
+// stepRecorder persists per-step progress of a running load test so the web console can show
+// detailed, real-time status with timing and error messages (FR-MA2-PERF-007-08). A nil
+// recorder (or one without a persisted state) is a no-op, so callers that have no execution
+// state can pass nil safely.
+type stepRecorder struct {
+	l     *LoadService
+	state *LoadTestExecutionState
+}
+
+func (l *LoadService) newStepRecorder(state *LoadTestExecutionState) *stepRecorder {
+	return &stepRecorder{l: l, state: state}
+}
+
+func (s *stepRecorder) upsert(step *LoadTestExecutionStep) {
+	if s == nil || s.state == nil || s.state.ID == 0 {
+		return
+	}
+	step.LoadTestExecutionStateId = s.state.ID
+	step.LoadTestKey = s.state.LoadTestKey
+	step.Seq = stepSeq[step.Name]
+	if err := s.l.loadRepo.UpsertLoadTestExecutionStepTx(context.Background(), step); err != nil {
+		log.Warn().Msgf("failed to record execution step %s; %v", step.Name, err)
+	}
+}
+
+// seed creates the full pipeline as pending so the web can render every step upfront.
+func (s *stepRecorder) seed() {
+	for name := range stepSeq {
+		s.upsert(&LoadTestExecutionStep{Name: name, Status: constant.StepPending})
+	}
+}
+
+func (s *stepRecorder) begin(name constant.ExecutionStep, message string) {
+	now := time.Now()
+	s.upsert(&LoadTestExecutionStep{Name: name, Status: constant.StepRunning, StartAt: &now, Message: message})
+}
+
+// progress updates a running step with a retry count and diagnostic detail
+// (e.g. "Installing JMeter (retry 1)").
+func (s *stepRecorder) progress(name constant.ExecutionStep, attempt int, message, detail string) {
+	s.upsert(&LoadTestExecutionStep{Name: name, Status: constant.StepRunning, Attempt: attempt, Message: message, Detail: detail})
+}
+
+func (s *stepRecorder) ok(name constant.ExecutionStep, message string) {
+	now := time.Now()
+	s.upsert(&LoadTestExecutionStep{Name: name, Status: constant.StepOk, FinishAt: &now, Message: message})
+}
+
+func (s *stepRecorder) fail(name constant.ExecutionStep, message, detail string) {
+	now := time.Now()
+	s.upsert(&LoadTestExecutionStep{Name: name, Status: constant.StepFailed, FinishAt: &now, Message: message, Detail: detail})
+}
+
+func (s *stepRecorder) skip(name constant.ExecutionStep, message string) {
+	s.upsert(&LoadTestExecutionStep{Name: name, Status: constant.StepSkipped, Message: message})
+}
+
 // RunLoadTest initiates the load test and performs necessary initializations.
 // Generates a load test key, installs the load generator or retrieves existing installation information,
 // saves the load test execution state, and then asynchronously runs the load test.
@@ -93,6 +159,10 @@ func (l *LoadService) processLoadTestAsync(param RunLoadTestParam, loadTestExecu
 		}
 	}()
 
+	// FR-MA2-PERF-007-08: record per-step progress for the web console.
+	rec := l.newStepRecorder(loadTestExecutionState)
+	rec.seed()
+
 	failed := func(logMsg string, occuredError error) {
 		log.Error().Msg(logMsg)
 		loadTestExecutionState.ExecutionStatus = constant.TestFailed
@@ -104,6 +174,7 @@ func (l *LoadService) processLoadTestAsync(param RunLoadTestParam, loadTestExecu
 
 	if param.LoadGeneratorInstallInfoId == uint(0) {
 		log.Info().Msgf("No LoadGeneratorInstallInfoId provided, installing load generator...")
+		rec.begin(constant.StepGeneratorInstall, "Installing load generator")
 
 		// ✅ VM 정보를 부하 발생기 설치 파라미터에 추가
 		installParam := param.InstallLoadGenerator
@@ -111,14 +182,20 @@ func (l *LoadService) processLoadTestAsync(param RunLoadTestParam, loadTestExecu
 		installParam.InfraId = param.InfraId
 		installParam.NodeId = param.NodeId
 
-		result, err := l.InstallLoadGenerator(installParam)
+		result, err := l.InstallLoadGenerator(installParam, func(attempt int, message, detail string) {
+			rec.progress(constant.StepGeneratorInstall, attempt, message, detail)
+		})
 		if err != nil {
+			rec.fail(constant.StepGeneratorInstall, "Load generator install failed", err.Error())
 			failed(fmt.Sprintf("Error installing load generator: %v", err), err)
 			return
 		}
 
+		rec.ok(constant.StepGeneratorInstall, "Load generator ready")
 		param.LoadGeneratorInstallInfoId = result.ID
 		log.Info().Msgf("Load generator installed with ID: %d", result.ID)
+	} else {
+		rec.ok(constant.StepGeneratorInstall, "Reusing existing generator")
 	}
 
 	loadGeneratorInstallInfo, err := l.loadRepo.GetValidLoadGeneratorInstallInfoByIdTx(context.Background(), param.LoadGeneratorInstallInfoId)
@@ -179,15 +256,18 @@ func (l *LoadService) processLoadTestAsync(param RunLoadTestParam, loadTestExecu
 	}
 
 	if param.CollectAdditionalSystemMetrics {
+		rec.begin(constant.StepAgentInstall, "Installing monitoring agent")
 		if strings.TrimSpace(param.AgentHostname) == "" {
 			mci, err := l.tumblebugClient.GetMciWithContext(context.Background(), param.NsId, param.InfraId)
 
 			if err != nil {
+				rec.fail(constant.StepAgentInstall, "Monitoring agent install failed", fmt.Sprintf("failed to look up target MCI: %v", err))
 				failed(fmt.Sprintf("unexpected error occurred while fetching mci for install metrics agent; %s", err), err)
 				return
 			}
 
 			if len(mci.Vm) == 0 {
+				rec.fail(constant.StepAgentInstall, "Monitoring agent install failed", "target MCI has no VM")
 				failed("mci vm's length is zero", errors.New("mci vm's length is zero"))
 				return
 			}
@@ -204,6 +284,7 @@ func (l *LoadService) processLoadTestAsync(param RunLoadTestParam, loadTestExecu
 
 			if param.AgentHostname == "" {
 				err := errors.New("agent host name afeter get mci from tumblebug must be set to not nil")
+				rec.fail(constant.StepAgentInstall, "Monitoring agent install failed", "could not resolve the target node hostname")
 				failed(fmt.Sprintf("invalid agent hostname for test %s; %v", param.LoadTestKey, err), err)
 				return
 			}
@@ -218,11 +299,15 @@ func (l *LoadService) processLoadTestAsync(param RunLoadTestParam, loadTestExecu
 		// install and run the agent for collect metrics
 		_, err := l.InstallMonitoringAgent(arg)
 		if err != nil {
+			rec.fail(constant.StepAgentInstall, "Monitoring agent install failed", err.Error())
 			failed(fmt.Sprintf("unexpected error occurred while installing monitoring agent; %s", err), err)
 			return
 		}
 
+		rec.ok(constant.StepAgentInstall, "Monitoring agent installed")
 		log.Info().Msgf("metrics agent installed successfully for load test; %s %s %s", arg.NsId, arg.InfraId, arg.NodeIds)
+	} else {
+		rec.skip(constant.StepAgentInstall, "Additional metrics not collected")
 	}
 
 	loadTestDone := make(chan bool)
@@ -256,6 +341,7 @@ func (l *LoadService) processLoadTestAsync(param RunLoadTestParam, loadTestExecu
 		Port:                           port,
 		CollectAdditionalSystemMetrics: param.CollectAdditionalSystemMetrics,
 		Home:                           home,
+		StepRec:                        rec,
 	}
 
 	go l.fetchData(dataParam)
@@ -272,7 +358,7 @@ func (l *LoadService) processLoadTestAsync(param RunLoadTestParam, loadTestExecu
 		log.Info().Msgf("successfully done load test for %s", dataParam.LoadTestKey)
 	}()
 
-	compileDuration, executionDuration, loadTestErr := l.executeLoadTest(param, &loadGeneratorInstallInfo)
+	compileDuration, executionDuration, loadTestErr := l.executeLoadTest(param, &loadGeneratorInstallInfo, rec)
 
 	loadTestExecutionState.CompileDuration = compileDuration
 	loadTestExecutionState.ExecutionDuration = executionDuration
@@ -389,7 +475,7 @@ func (l *LoadService) processLoadTest(param RunLoadTestParam, loadGeneratorInsta
 		log.Info().Msgf("successfully done load test for %s", dataParam.LoadTestKey)
 	}()
 
-	compileDuration, executionDuration, loadTestErr := l.executeLoadTest(param, loadGeneratorInstallInfo)
+	compileDuration, executionDuration, loadTestErr := l.executeLoadTest(param, loadGeneratorInstallInfo, nil)
 
 	loadTestExecutionState.CompileDuration = compileDuration
 	loadTestExecutionState.ExecutionDuration = executionDuration
@@ -414,7 +500,7 @@ func (l *LoadService) processLoadTest(param RunLoadTestParam, loadGeneratorInsta
 	loadTestExecutionState.ExecutionStatus = constant.Successed
 }
 
-func (l *LoadService) executeLoadTest(param RunLoadTestParam, loadGeneratorInstallInfo *LoadGeneratorInstallInfo) (string, string, error) {
+func (l *LoadService) executeLoadTest(param RunLoadTestParam, loadGeneratorInstallInfo *LoadGeneratorInstallInfo, rec *stepRecorder) (string, string, error) {
 	installLocation := loadGeneratorInstallInfo.InstallLocation
 	loadTestKey := param.LoadTestKey
 	loadGeneratorInstallPath := loadGeneratorInstallInfo.InstallPath
@@ -429,9 +515,11 @@ func (l *LoadService) executeLoadTest(param RunLoadTestParam, loadGeneratorInsta
 
 	if installLocation == constant.Remote {
 		log.Info().Msg("Remote execute detected.")
+		rec.begin(constant.StepJmxPrepare, "Preparing and sending test plan")
 		var buf bytes.Buffer
 		err := parseTestPlanStructToString(&buf, param, loadGeneratorInstallInfo)
 		if err != nil {
+			rec.fail(constant.StepJmxPrepare, "Test plan generation failed", err.Error())
 			return compileDuration, executionDuration, err
 		}
 
@@ -447,9 +535,12 @@ func (l *LoadService) executeLoadTest(param RunLoadTestParam, loadGeneratorInsta
 		nsId, mciId, _, _ := getResourceNames()
 		_, err = l.tumblebugClient.CommandToMciWithContext(context.Background(), nsId, mciId, commandReq)
 		if err != nil {
+			rec.fail(constant.StepJmxPrepare, "Test plan transfer failed", err.Error())
 			return compileDuration, executionDuration, err
 		}
+		rec.ok(constant.StepJmxPrepare, "Test plan ready")
 
+		rec.begin(constant.StepJmeterRun, "Running load test")
 		jmeterTestCommand := generateJmeterExecutionCmd(loadGeneratorInstallPath, loadGeneratorInstallVersion, testPlanName, resultFileName)
 
 		commandReq = tumblebug.SendCommandReq{
@@ -458,13 +549,16 @@ func (l *LoadService) executeLoadTest(param RunLoadTestParam, loadGeneratorInsta
 
 		stdout, err := l.tumblebugClient.CommandToMciWithContext(context.Background(), nsId, mciId, commandReq)
 		if err != nil {
+			rec.fail(constant.StepJmeterRun, "Load test failed", err.Error())
 			return compileDuration, executionDuration, err
 		}
 		executionDuration = utils.DurationString(start)
 
 		if strings.Contains(stdout, "exited with status 1") {
+			rec.fail(constant.StepJmeterRun, "Load test failed", "jmeter test stopped unexpectedly")
 			return compileDuration, executionDuration, errors.New("jmeter test stopped unexpectedly")
 		}
+		rec.ok(constant.StepJmeterRun, "Load test finished")
 
 	} else if installLocation == constant.Local {
 		log.Info().Msg("Local execute detected.")

--- a/internal/core/load/models.go
+++ b/internal/core/load/models.go
@@ -94,6 +94,25 @@ type LoadTestExecutionState struct {
 	// not to make one to one relationship between LoadTestExecutionInfo and LoadGeneratorInstallInfo
 	TestExecutionInfoId    uint
 	GeneratorInstallInfoId uint
+
+	// Steps are the per-stage progress records (FR-MA2-PERF-007-08).
+	Steps []LoadTestExecutionStep `gorm:"foreignKey:LoadTestExecutionStateId;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
+}
+
+// LoadTestExecutionStep records the status of one stage of a load test run so the web
+// console can show detailed, real-time progress (FR-MA2-PERF-007-08).
+type LoadTestExecutionStep struct {
+	gorm.Model
+	LoadTestExecutionStateId uint   `gorm:"index:idx_step_state_name,unique;index"`
+	LoadTestKey              string `gorm:"index"`
+	Seq                      int
+	Name                     constant.ExecutionStep `gorm:"index:idx_step_state_name,unique"`
+	Status                   constant.StepStatus
+	Attempt                  int
+	StartAt                  *time.Time
+	FinishAt                 *time.Time
+	Message                  string // short current-status line (e.g. "Installing JMeter (retry 1)")
+	Detail                   string // verbose diagnosis / error cause
 }
 
 type LoadTestExecutionInfo struct {

--- a/internal/core/load/performace_evaluation_service.go
+++ b/internal/core/load/performace_evaluation_service.go
@@ -172,6 +172,20 @@ func mapLoadTestExecutionStateResult(state LoadTestExecutionState) LoadTestExecu
 		stateResult.IconCode = constant.Pending
 	}
 
+	// FR-MA2-PERF-007-08: expose per-step progress.
+	for _, s := range state.Steps {
+		stateResult.Steps = append(stateResult.Steps, LoadTestExecutionStepResult{
+			Seq:      s.Seq,
+			Name:     s.Name,
+			Status:   s.Status,
+			Attempt:  s.Attempt,
+			StartAt:  s.StartAt,
+			FinishAt: s.FinishAt,
+			Message:  s.Message,
+			Detail:   s.Detail,
+		})
+	}
+
 	return *stateResult
 
 }

--- a/internal/core/load/repository.go
+++ b/internal/core/load/repository.go
@@ -302,6 +302,35 @@ func (r *LoadRepository) UpdateLoadTestExecutionStateTx(ctx context.Context, par
 	return err
 }
 
+// UpsertLoadTestExecutionStepTx creates or updates a step by (state id, name) so each stage
+// keeps exactly one row that is updated in place as it transitions (FR-MA2-PERF-007-08).
+func (r *LoadRepository) UpsertLoadTestExecutionStepTx(ctx context.Context, step *LoadTestExecutionStep) error {
+	return r.execInTransaction(ctx, func(d *gorm.DB) error {
+		var existing LoadTestExecutionStep
+		err := d.
+			Where("load_test_execution_state_id = ? AND name = ?", step.LoadTestExecutionStateId, step.Name).
+			First(&existing).Error
+
+		if err == gorm.ErrRecordNotFound {
+			return d.Create(step).Error
+		} else if err != nil {
+			return err
+		}
+
+		step.ID = existing.ID
+		step.CreatedAt = existing.CreatedAt
+		// Preserve fields the caller left unset so a transition (running -> ok/failed) keeps
+		// the original start time and sequence.
+		if step.StartAt == nil {
+			step.StartAt = existing.StartAt
+		}
+		if step.Seq == 0 {
+			step.Seq = existing.Seq
+		}
+		return d.Save(step).Error
+	})
+}
+
 func (r *LoadRepository) UpdateLoadTestExecutionInfoDuration(ctx context.Context, loadTestKey, compileDuration, executionDuration string) error {
 	err := r.execInTransaction(ctx, func(d *gorm.DB) error {
 		err := d.
@@ -330,6 +359,9 @@ func (r *LoadRepository) GetPagingLoadTestExecutionStateTx(ctx context.Context, 
 		q := d.Model(&LoadTestExecutionState{}).
 			// Preload("LoadGeneratorInstallInfo").
 			// Preload("LoadGeneratorInstallInfo.LoadGeneratorServers").
+			Preload("Steps", func(db *gorm.DB) *gorm.DB {
+				return db.Order("seq asc")
+			}).
 			Order("load_test_execution_states.created_at desc")
 
 		if param.LoadTestKey != "" {
@@ -361,8 +393,10 @@ func (r *LoadRepository) GetLoadTestExecutionStateTx(ctx context.Context, param 
 
 	err := r.execInTransaction(ctx, func(d *gorm.DB) error {
 
-		q := d.Model(&loadTestExecutionState)
-
+		q := d.Model(&loadTestExecutionState).
+			Preload("Steps", func(db *gorm.DB) *gorm.DB {
+				return db.Order("seq asc")
+			})
 
 		if param.LoadTestKey != "" {
 			q = q.Where("load_test_execution_states.load_test_key = ?", param.LoadTestKey)
@@ -402,6 +436,9 @@ func (r *LoadRepository) GetPagingLoadTestExecutionHistoryTx(ctx context.Context
 	err := r.execInTransaction(ctx, func(d *gorm.DB) error {
 		q := d.Model(&LoadTestExecutionInfo{}).
 			Preload("LoadTestExecutionState").
+			Preload("LoadTestExecutionState.Steps", func(db *gorm.DB) *gorm.DB {
+				return db.Order("seq asc")
+			}).
 			Preload("LoadTestExecutionHttpInfos").
 			Preload("LoadGeneratorInstallInfo").
 			Preload("LoadGeneratorInstallInfo.LoadGeneratorServers").
@@ -429,6 +466,9 @@ func (r *LoadRepository) GetLoadTestExecutionInfoTx(ctx context.Context, param G
 	err := r.execInTransaction(ctx, func(d *gorm.DB) error {
 		return d.Model(&loadTestExecutionInfo).
 			Preload("LoadTestExecutionState").
+			Preload("LoadTestExecutionState.Steps", func(db *gorm.DB) *gorm.DB {
+				return db.Order("seq asc")
+			}).
 			Preload("LoadTestExecutionHttpInfos").
 			Preload("LoadGeneratorInstallInfo").
 			Preload("LoadGeneratorInstallInfo.LoadGeneratorServers").

--- a/internal/core/load/rsync_fetch_service.go
+++ b/internal/core/load/rsync_fetch_service.go
@@ -26,6 +26,7 @@ type fetchDataParam struct {
 	fetchMx                        sync.Mutex
 	fetchRunning                   bool
 	Home                           string
+	StepRec                        *stepRecorder // FR-MA2-PERF-007-08 (nil = no recording)
 }
 
 func (f *fetchDataParam) setFetchRunning(running bool) {
@@ -60,16 +61,28 @@ func (l *LoadService) fetchData(f *fetchDataParam) {
 				f.setFetchRunning(false)
 			}
 		case <-done:
+			// FR-MA2-PERF-007-08: record the final result collection as its own step so a
+			// rsync failure is visible (previously it was only logged and the run was still
+			// marked successed).
+			f.StepRec.begin(constant.StepResultFetch, "Collecting results")
 			retry := config.AppConfig.Load.Retry
+			var fetchErr error
 			for retry > 0 {
 				if !f.isRunning() {
-					if err := rsyncFiles(f); err != nil {
-						log.Error().Msgf("error while fetching data from rsync %s", err.Error())
+					fetchErr = rsyncFiles(f)
+					if fetchErr != nil {
+						log.Error().Msgf("error while fetching data from rsync %s", fetchErr.Error())
 					}
 					break
 				}
 				time.Sleep(time.Duration(1<<4-retry) * time.Second)
 				retry--
+			}
+
+			if fetchErr != nil {
+				f.StepRec.fail(constant.StepResultFetch, "Result collection failed", fmt.Sprintf("the load test finished but collecting the result files (rsync) failed: %v", fetchErr))
+			} else {
+				f.StepRec.ok(constant.StepResultFetch, "Results collected")
 			}
 
 			return

--- a/internal/infra/db/db.go
+++ b/internal/infra/db/db.go
@@ -31,6 +31,7 @@ func migrateDB(defaultDb *gorm.DB) error {
 		&load.LoadTestExecutionInfo{},
 		&load.LoadTestExecutionHttpInfo{},
 		&load.LoadTestExecutionState{},
+		&load.LoadTestExecutionStep{},
 		&load.LoadTestScenarioCatalog{},
 
 		&cost.EstimateCostInfo{},


### PR DESCRIPTION
## What

Exposes per-step execution status (`steps[]`) on the load test state/infos responses so a console can render detailed, real-time progress.

> Note: this builds on #55 (load generator self-heal). Until #55 merges, this PR's diff also shows those commits; it reduces to the steps[] change afterwards.

## Why

A load test run goes through several stages (generator install → monitoring agent install → test plan → JMeter run → result collection), but the status was only a coarse three-state value. There was no way to tell which stage was running, when it started, or where it failed. In particular, a result-collection (rsync) failure was not reflected in the status, so a run could be marked `successed` even when the results were never collected.

## How

Adds a `LoadTestExecutionStep` record (auto-migrated) and a `steps[]` array on the state, each step carrying a name, status (pending/running/ok/failed/skipped), start/finish times, an attempt counter, a short message, and a verbose detail. `processLoadTestAsync` and the rsync fetch loop record each transition, so a result-collection failure is now surfaced as `result_fetch=failed` while the overall run stays `successed` when the measurement itself succeeded. The existing coarse `executionStatus` and response fields are unchanged for backward compatibility, and the swagger spec is regenerated.

## Result

The state/infos responses now include per-step progress with timing and messages, and a result-collection failure is visible instead of being silently marked as success. Verified end-to-end against a development environment: a normal run reports each step, and a run whose result collection fails reports `result_fetch=failed` while keeping the overall status `successed`. `go build` / `go vet` / package tests pass.