### PR TITLE
fix(load): record which VM a load test ran on, not just what it was called

### DIFF
--- a/internal/core/load/dtos.go
+++ b/internal/core/load/dtos.go
@@ -8,7 +8,7 @@ import (
 
 // MonitoringAgentInstallationParams represents parameters for installing a monitoring agent.
 type MonitoringAgentInstallationParams struct {
-	NsId  string   `json:"nsId"`
+	NsId    string   `json:"nsId"`
 	InfraId string   `json:"infraId"`
 	NodeIds []string `json:"nodeIds,omitempty"`
 }
@@ -17,8 +17,8 @@ type MonitoringAgentInstallationParams struct {
 type MonitoringAgentInstallationResult struct {
 	ID        uint      `json:"id,omitempty"`
 	NsId      string    `json:"nsId,omitempty"`
-	InfraId     string    `json:"infraId,omitempty"`
-	NodeId      string    `json:"nodeId,omitempty"`
+	InfraId   string    `json:"infraId,omitempty"`
+	NodeId    string    `json:"nodeId,omitempty"`
 	VmCount   int       `json:"vmCount,omitempty"`
 	Status    string    `json:"status,omitempty"`
 	Username  string    `json:"username,omitempty"`
@@ -28,9 +28,9 @@ type MonitoringAgentInstallationResult struct {
 }
 
 type GetAllMonitoringAgentInfosParam struct {
-	Page  int    `json:"page"`
-	Size  int    `json:"size"`
-	NsId  string `json:"nsId,omitempty"`
+	Page    int    `json:"page"`
+	Size    int    `json:"size"`
+	NsId    string `json:"nsId,omitempty"`
 	InfraId string `json:"infraId,omitempty"`
 	NodeId  string `json:"nodeId,omitempty"`
 }
@@ -44,7 +44,7 @@ type InstallLoadGeneratorParam struct {
 	InstallLocation constant.InstallLocation `json:"installLocation,omitempty"`
 	Coordinates     []string                 `json:"coordinate"`
 	// VM 정보 추가 (CSP 매칭용)
-	NsId  string `json:"nsId,omitempty"`
+	NsId    string `json:"nsId,omitempty"`
 	InfraId string `json:"infraId,omitempty"`
 	NodeId  string `json:"nodeId,omitempty"`
 }
@@ -63,7 +63,7 @@ type LoadGeneratorServerResult struct {
 	Lat             string    `json:"lat,omitempty"`
 	Lon             string    `json:"lon,omitempty"`
 	Username        string    `json:"username,omitempty"`
-	NodeId            string    `json:"nodeId,omitempty"`
+	NodeId          string    `json:"nodeId,omitempty"`
 	StartTime       string    `json:"startTime,omitempty"`
 	AdditionalVmKey string    `json:"additionalVmKey,omitempty"`
 	Label           string    `json:"label,omitempty"`
@@ -114,7 +114,7 @@ type RunLoadTestParam struct {
 	RampUpSteps  string `json:"rampUpSteps"`
 
 	// related tumblebug
-	NsId  string `json:"nsId"`
+	NsId    string `json:"nsId"`
 	InfraId string `json:"infraId"`
 	NodeId  string `json:"nodeId"`
 
@@ -146,21 +146,25 @@ type GetAllLoadTestExecutionStateResult struct {
 }
 
 type LoadTestExecutionStateResult struct {
-	ID                          uint                           `json:"id"`
-	LoadGeneratorInstallInfoId  uint                           `json:"loadGeneratorInstallInfoId,omitempty"`
-	LoadGeneratorInstallInfo    LoadGeneratorInstallInfoResult `json:"loadGeneratorInstallInfo,omitempty"`
-	LoadTestKey                 string                         `json:"loadTestKey,omitempty"`
-	ExecutionStatus             constant.ExecutionStatus       `json:"executionStatus,omitempty"`
-	StartAt                     time.Time                      `json:"startAt,omitempty"`
-	FinishAt                    *time.Time                     `json:"finishAt,omitempty"`
-	ExpectedFinishAt            time.Time                      `json:"expectedFinishAt,omitempty"`
-	IconCode                    constant.IconCode              `json:"iconCode"`
-	TotalExpectedExcutionSecond uint64                         `json:"totalExpectedExecutionSecond,omitempty"`
-	FailureMessage              string                         `json:"failureMessage,omitempty"`
-	CompileDuration             string                         `json:"compileDuration,omitempty"`
-	ExecutionDuration           string                         `json:"executionDuration,omitempty"`
-	CreatedAt                   time.Time                      `json:"createdAt,omitempty"`
-	UpdatedAt                   time.Time                      `json:"updatedAt,omitempty"`
+	ID                         uint                           `json:"id"`
+	LoadGeneratorInstallInfoId uint                           `json:"loadGeneratorInstallInfoId,omitempty"`
+	LoadGeneratorInstallInfo   LoadGeneratorInstallInfoResult `json:"loadGeneratorInstallInfo,omitempty"`
+	LoadTestKey                string                         `json:"loadTestKey,omitempty"`
+	// NodeUid identifies which VM this run belongs to. Node ids are names and get reused,
+	// so a caller that keeps showing "the last run for this node" needs the uid to notice
+	// that the answer belongs to a VM that has since been replaced.
+	NodeUid                     string                   `json:"nodeUid,omitempty"`
+	ExecutionStatus             constant.ExecutionStatus `json:"executionStatus,omitempty"`
+	StartAt                     time.Time                `json:"startAt,omitempty"`
+	FinishAt                    *time.Time               `json:"finishAt,omitempty"`
+	ExpectedFinishAt            time.Time                `json:"expectedFinishAt,omitempty"`
+	IconCode                    constant.IconCode        `json:"iconCode"`
+	TotalExpectedExcutionSecond uint64                   `json:"totalExpectedExecutionSecond,omitempty"`
+	FailureMessage              string                   `json:"failureMessage,omitempty"`
+	CompileDuration             string                   `json:"compileDuration,omitempty"`
+	ExecutionDuration           string                   `json:"executionDuration,omitempty"`
+	CreatedAt                   time.Time                `json:"createdAt,omitempty"`
+	UpdatedAt                   time.Time                `json:"updatedAt,omitempty"`
 	// Steps is the per-stage progress of the run (FR-MA2-PERF-007-08), ordered by seq.
 	Steps []LoadTestExecutionStepResult `json:"steps,omitempty"`
 }
@@ -182,8 +186,8 @@ type LoadTestExecutionStepResult struct {
 type GetLoadTestExecutionStateParam struct {
 	LoadTestKey string `json:"loadTestKey"`
 	NsId        string `json:"nsId"`
-	InfraId       string `json:"infraId"`
-	NodeId        string `json:"nodeId"`
+	InfraId     string `json:"infraId"`
+	NodeId      string `json:"nodeId"`
 }
 
 type GetAllLoadTestExecutionInfosParam struct {
@@ -230,8 +234,8 @@ type GetLoadTestExecutionInfoParam struct {
 type StopLoadTestParam struct {
 	LoadTestKey string `json:"loadTestKey"`
 	NsId        string `json:"nsId"`
-	InfraId       string `json:"infraId"`
-	NodeId        string `json:"nodeId"`
+	InfraId     string `json:"infraId"`
+	NodeId      string `json:"nodeId"`
 }
 
 type ResultSummary struct {
@@ -286,10 +290,10 @@ type GetLoadTestResultParam struct {
 }
 
 type GetLastLoadTestResultParam struct {
-	NsId   string
-	InfraId  string
-	NodeId   string
-	Format constant.ResultFormat
+	NsId    string
+	InfraId string
+	NodeId  string
+	Format  constant.ResultFormat
 }
 
 // LoadTestScenarioCatalog DTOs

--- a/internal/core/load/load_test_execution_service.go
+++ b/internal/core/load/load_test_execution_service.go
@@ -102,6 +102,24 @@ var generatorRunMu sync.Mutex
 // RunLoadTest initiates the load test and performs necessary initializations.
 // Generates a load test key, installs the load generator or retrieves existing installation information,
 // saves the load test execution state, and then asynchronously runs the load test.
+// resolveNodeUid asks cb-tumblebug which VM the given node name currently refers to.
+//
+// Returns "" when the lookup fails. A load test is worth running even if we cannot label it,
+// and an empty uid is understood downstream as "unknown" rather than as a mismatch - the
+// same treatment rows written before this column existed get.
+func (l *LoadService) resolveNodeUid(ctx context.Context, nsId, infraId, nodeId string) string {
+	if nsId == "" || infraId == "" || nodeId == "" {
+		return ""
+	}
+
+	vm, err := l.tumblebugClient.GetVmWithContext(ctx, nsId, infraId, nodeId)
+	if err != nil {
+		log.Warn().Msgf("could not resolve node uid for %s/%s/%s: %v", nsId, infraId, nodeId, err)
+		return ""
+	}
+	return vm.Uid
+}
+
 func (l *LoadService) RunLoadTest(param RunLoadTestParam) (string, error) {
 	timeout, err := time.ParseDuration(config.AppConfig.Load.Timeout.CommandExecution)
 	if err != nil {
@@ -142,6 +160,17 @@ func (l *LoadService) RunLoadTest(param RunLoadTestParam) (string, error) {
 	startAt := time.Now()
 	e := startAt.Add(time.Duration(totalExecutionSecond) * time.Second)
 
+	// Record which VM this run belongs to, not just what it was called.
+	//
+	// Node ids are names that get reused: cb-tumblebug builds them as "{group}-{index}", so
+	// deleting a VM and recreating it under the same name gives an identical
+	// ns/infra/node triple. Without the uid a later lookup cannot tell whether the run it
+	// found belongs to the VM in front of the user or to its predecessor.
+	//
+	// Resolved here rather than taken from the request: the client would have to send it
+	// correctly for the guarantee to hold, and cb-tumblebug already answers the question.
+	nodeUid := l.resolveNodeUid(ctx, param.NsId, param.InfraId, param.NodeId)
+
 	stateArg := LoadTestExecutionState{
 		LoadTestKey:                 loadTestKey,
 		ExecutionStatus:             constant.OnProcessing,
@@ -151,6 +180,7 @@ func (l *LoadService) RunLoadTest(param RunLoadTestParam) (string, error) {
 		NsId:                        param.NsId,
 		InfraId:                     param.InfraId,
 		NodeId:                      param.NodeId,
+		NodeUid:                     nodeUid,
 		WithMetrics:                 param.CollectAdditionalSystemMetrics,
 	}
 
@@ -657,6 +687,20 @@ func generateJmeterExecutionCmd(loadGeneratorInstallPath, loadGeneratorInstallVe
 	return builder.String()
 }
 
+// belongsToDifferentNode reports whether a recorded run demonstrably belongs to a VM other
+// than the one being asked about.
+//
+// Only a disagreement between two known uids counts. An unknown uid on either side - a run
+// recorded before the column existed, or cb-tumblebug being unreachable - is not evidence of
+// anything, and treating it as a mismatch would block stopping runs that are perfectly
+// legitimate.
+func belongsToDifferentNode(recordedUid, currentUid string) bool {
+	if recordedUid == "" || currentUid == "" {
+		return false
+	}
+	return recordedUid != currentUid
+}
+
 func (l *LoadService) StopLoadTest(param StopLoadTestParam) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -680,6 +724,26 @@ func (l *LoadService) StopLoadTest(param StopLoadTestParam) error {
 
 	if err != nil {
 		return fmt.Errorf("error occurred while retrieve load test execution state: %w", err)
+	}
+
+	// Stopping by name alone can hit the wrong run.
+	//
+	// Without a load test key the lookup above is "the most recent run for this ns/infra/node",
+	// and those are names that get reused - a VM recreated under the old name inherits them.
+	// The run that comes back may therefore belong to the previous VM, and stopping it would
+	// kill a test nobody asked to stop. Reading is merely misleading; this is destructive.
+	//
+	// A stored uid that disagrees with the live one means exactly that case. An empty uid on
+	// either side means "unknown" (rows predating the column, or cb-tumblebug unreachable) and
+	// is left alone rather than guessed at.
+	if param.LoadTestKey == "" {
+		currentUid := l.resolveNodeUid(ctx, param.NsId, param.InfraId, param.NodeId)
+		if belongsToDifferentNode(state.NodeUid, currentUid) {
+			return fmt.Errorf(
+				"the most recent load test on %s/%s/%s belongs to a different VM (recorded uid %s, current uid %s); pass its load test key to stop it",
+				param.NsId, param.InfraId, param.NodeId, state.NodeUid, currentUid,
+			)
+		}
 	}
 
 	if state.ExecutionStatus == constant.Successed {

--- a/internal/core/load/load_test_execution_service.go
+++ b/internal/core/load/load_test_execution_service.go
@@ -726,16 +726,18 @@ func (l *LoadService) StopLoadTest(param StopLoadTestParam) error {
 		return fmt.Errorf("error occurred while retrieve load test execution state: %w", err)
 	}
 
-	// Stopping by name alone can hit the wrong run.
+	// Guard the key-less lookup, which resolves to "the most recent run for this
+	// ns/infra/node" - names that get reused, so the run may belong to a VM that has since
+	// been replaced. Stopping that one would kill a test nobody asked about.
 	//
-	// Without a load test key the lookup above is "the most recent run for this ns/infra/node",
-	// and those are names that get reused - a VM recreated under the old name inherits them.
-	// The run that comes back may therefore belong to the previous VM, and stopping it would
-	// kill a test nobody asked to stop. Reading is merely misleading; this is destructive.
+	// Not reachable over HTTP today: the handler rejects a stop request that omits the load
+	// test key, so callers always arrive with one and take the branch above. The guard is
+	// here because the service accepts the key-less shape and nothing but this handler check
+	// stands between it and the wrong test.
 	//
-	// A stored uid that disagrees with the live one means exactly that case. An empty uid on
-	// either side means "unknown" (rows predating the column, or cb-tumblebug unreachable) and
-	// is left alone rather than guessed at.
+	// A stored uid that disagrees with the live one is that case. An empty uid on either side
+	// means "unknown" (rows predating the column, or cb-tumblebug unreachable) and is left
+	// alone rather than guessed at.
 	if param.LoadTestKey == "" {
 		currentUid := l.resolveNodeUid(ctx, param.NsId, param.InfraId, param.NodeId)
 		if belongsToDifferentNode(state.NodeUid, currentUid) {

--- a/internal/core/load/models.go
+++ b/internal/core/load/models.go
@@ -15,8 +15,8 @@ type MonitoringAgentInfo struct {
 	AgentType string
 
 	NsId    string
-	InfraId   string
-	NodeId    string
+	InfraId string
+	NodeId  string
 	VmCount int
 }
 
@@ -37,7 +37,7 @@ type LoadGeneratorServer struct {
 	Lat             string
 	Lon             string
 	Username        string
-	NodeId            string
+	NodeId          string
 	StartTime       string
 	AdditionalVmKey string
 	Label           string
@@ -77,9 +77,22 @@ type LoadTestExecutionState struct {
 	gorm.Model
 	LoadTestKey string `gorm:"index:idx_state_load_test_key,unique"`
 
-	NsId  string
+	NsId    string
 	InfraId string
 	NodeId  string
+
+	// NodeUid is cb-tumblebug's generated identifier for the node under test.
+	//
+	// NsId/InfraId/NodeId are *names*: cb-tumblebug builds a node id as "{group name}-{index
+	// within the group}" and reuses it when the same names are used again. Deleting a VM and
+	// recreating it with the same name therefore produces an identical NsId/InfraId/NodeId,
+	// and a lookup by those alone returns the previous VM's run - a result belonging to a
+	// machine that no longer exists. Only the uid is regenerated per VM, so it is what tells
+	// two generations apart.
+	//
+	// Empty for runs recorded before this column existed; callers must treat "" as unknown
+	// rather than as a mismatch.
+	NodeUid string
 
 	ExecutionStatus             constant.ExecutionStatus
 	StartAt                     time.Time
@@ -124,7 +137,7 @@ type LoadTestExecutionInfo struct {
 	RampUpTime   string
 	RampUpSteps  string
 
-	NsId  string
+	NsId    string
 	InfraId string
 	NodeId  string
 

--- a/internal/core/load/node_uid_test.go
+++ b/internal/core/load/node_uid_test.go
@@ -1,0 +1,82 @@
+package load
+
+import "testing"
+
+// These tests exist because cb-tumblebug node ids are names, not identities. A node id is
+// built as "{group name}-{index within the group}", so deleting a VM and recreating it under
+// the same name yields an identical ns/infra/node triple. Runs recorded against that triple
+// alone cannot be attributed to a particular VM; only the uid, regenerated per VM, can.
+
+// TestBelongsToDifferentNode covers the decision that guards stopping a load test.
+//
+// Getting this wrong is destructive in one direction and obstructive in the other: too
+// lenient and a stop request kills a run belonging to the VM's predecessor, too strict and
+// legitimate stops start failing for runs recorded before the uid existed.
+func TestBelongsToDifferentNode(t *testing.T) {
+	cases := []struct {
+		name        string
+		recordedUid string
+		currentUid  string
+		want        bool
+		why         string
+	}{
+		{
+			name:        "same vm",
+			recordedUid: "tbaaa111",
+			currentUid:  "tbaaa111",
+			want:        false,
+			why:         "the run belongs to the VM being asked about",
+		},
+		{
+			name:        "recreated under the same name",
+			recordedUid: "tbaaa111",
+			currentUid:  "tbbbb222",
+			want:        true,
+			why:         "same names, different VM - this is the case worth refusing",
+		},
+		{
+			name:        "run predates the uid column",
+			recordedUid: "",
+			currentUid:  "tbbbb222",
+			want:        false,
+			why:         "unknown is not a mismatch; refusing would block old but valid runs",
+		},
+		{
+			name:        "cb-tumblebug could not be reached",
+			recordedUid: "tbaaa111",
+			currentUid:  "",
+			want:        false,
+			why:         "a failed lookup says nothing about which VM this is",
+		},
+		{
+			name:        "neither side known",
+			recordedUid: "",
+			currentUid:  "",
+			want:        false,
+			why:         "no evidence either way",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := belongsToDifferentNode(c.recordedUid, c.currentUid); got != c.want {
+				t.Errorf("belongsToDifferentNode(%q, %q) = %v, want %v — %s",
+					c.recordedUid, c.currentUid, got, c.want, c.why)
+			}
+		})
+	}
+}
+
+// TestMapLoadTestExecutionStateResult_ExposesNodeUid makes sure callers can tell which VM a
+// run belongs to. Without the uid in the response the console cannot notice that "the last
+// run for this node" describes a VM that has since been replaced.
+func TestMapLoadTestExecutionStateResult_ExposesNodeUid(t *testing.T) {
+	got := mapLoadTestExecutionStateResult(LoadTestExecutionState{
+		LoadTestKey: "key-1",
+		NodeUid:     "tbabc123def456ghi789",
+	})
+
+	if got.NodeUid != "tbabc123def456ghi789" {
+		t.Errorf("expected the node uid to reach the response, got %q", got.NodeUid)
+	}
+}

--- a/internal/core/load/performace_evaluation_service.go
+++ b/internal/core/load/performace_evaluation_service.go
@@ -152,6 +152,7 @@ func mapLoadTestExecutionStateResult(state LoadTestExecutionState) LoadTestExecu
 	stateResult := &LoadTestExecutionStateResult{
 		ID:                          state.ID,
 		LoadTestKey:                 state.LoadTestKey,
+		NodeUid:                     state.NodeUid,
 		ExecutionStatus:             state.ExecutionStatus,
 		StartAt:                     state.StartAt,
 		FinishAt:                    state.FinishAt,
@@ -205,7 +206,7 @@ func mapLoadGeneratorServerResult(s LoadGeneratorServer) LoadGeneratorServerResu
 		Lat:             s.Lat,
 		Lon:             s.Lon,
 		Username:        s.Username,
-		NodeId:            s.NodeId,
+		NodeId:          s.NodeId,
 		StartTime:       s.StartTime,
 		AdditionalVmKey: s.AdditionalVmKey,
 		Label:           s.Label,


### PR DESCRIPTION
## Problem

Load test runs are stored and looked up by namespace, infra and node id. All three are names, and cb-tumblebug builds a node id as the group name plus an index within that group, so deleting a VM and recreating it under the same name reproduces the same triple.

Asking for the last run on that node then returns the previous VM's run. When the new VM has not been tested yet, it returns it every time.

Neither `load_test_execution_states` nor `load_test_execution_infos` carries a uid, so there is no information stored that could tell two generations apart.

Reproduced on a live environment: same node id after recreation, different VM uid, and `state/last` returned the deleted VM's run.

## Change

Runs now also record the node uid, which cb-tumblebug regenerates per VM. It is resolved server side from cb-tumblebug rather than accepted from the caller — a guarantee that depends on every client sending the right value is not much of a guarantee, and this service already talks to cb-tumblebug and parses that field for the load generator.

Responses expose it so callers can see whether the run they were given belongs to the VM in front of them. **The lookup itself is unchanged**: "the last run on this node" is a fair answer to that question, and whether it belongs to the VM currently on screen is the caller's judgement. Hiding results server side would break other uses such as history browsing.

An unknown uid on either side is treated as unknown rather than as a mismatch. Rows predate the column, and cb-tumblebug can be unreachable; refusing in those cases would block behaviour that is perfectly legitimate. That decision is isolated in one function and covered by tests for all five cases.

A guard was also added to the key-less stop path, which resolves to the most recent run for a name and could therefore stop a test on a different VM. It is not reachable over HTTP today — the handler requires a load test key — but the service accepts that shape and only the handler check stands between it and the wrong test.

## Notes

Column is added through the existing AutoMigrate; existing rows keep an empty uid. Field alignment elsewhere in `models.go` shifted because gofmt runs over the whole file.