### PR TITLE
feat(load): record the requested config up front, and report result collection per file

### DIFF
--- a/docs/load-test-status-api.md
+++ b/docs/load-test-status-api.md
@@ -1,0 +1,101 @@
+# Load test — reading a run's status and steps
+
+A load test runs asynchronously: the request to start one returns immediately with a
+`loadTestKey`, and the run then goes through pre-check, generator install, the load itself and
+result collection on its own. This page describes how a client (the web console, a script)
+reads where a run is, so a screen can show progress and explain a failure without guessing.
+
+## The status endpoint
+
+`GET /api/v1/load/tests/state/last` (operationId `GetLastLoadTestExecutionState`) returns the
+last run for a node. The node is identified by `nsId` / `mciId` / `vmId` in the query.
+
+The result is one `LoadTestExecutionState`:
+
+| Field | Meaning |
+|---|---|
+| `executionStatus` | Where the run is, overall — see below |
+| `startAt` / `finishAt` | When the run started, and finished (finish is null while running) |
+| `expectedFinishAt`, `totalExpectedExecutionSecond` | The expected end, derived from duration + ramp-up. A hint for a progress bar, not a promise — the checks and installs before the load are not counted |
+| `failureMessage` | A one-line reason when the run failed |
+| `nodeUid` | The *uid* of the target node. Node ids are names and get reused, so a caller that keeps showing "the last run for this node" needs the uid to notice the answer belongs to a VM that has since been replaced |
+| `steps` | The per-step progress, as a tree — see [Steps](#steps) |
+
+### executionStatus
+
+| Value | Meaning |
+|---|---|
+| `on_processing` | Running — checks, installs, or the load itself |
+| `on_fetching` | The load has finished and results are being collected |
+| `successed` | Finished; results are available |
+| `test_failed` | Stopped before finishing; `failureMessage` says why |
+
+## Steps
+
+`steps` is the progress of the run as a **tree**: the top level is the *phases* a run goes
+through, and each phase carries its *sub-steps* in `children`. A caller that only wants the
+phases can ignore `children` and read the six phase rows.
+
+Each node — a phase or a sub-step — is one `LoadTestExecutionStepResult`:
+
+| Field | Meaning |
+|---|---|
+| `seq` | Order within the run |
+| `name` | The step identifier. A phase is a bare name (`precheck`); a sub-step is `phase.sub` (`precheck.target_reachable`), the part before the dot naming its phase |
+| `status` | `pending` · `running` · `ok` · `failed` · `skipped` |
+| `attempt` | Retry count (0 = first try) |
+| `startAt` / `finishAt` | When this step started and finished |
+| `message` | A short, current-status line (e.g. `Checking the metric agent port`) |
+| `detail` | The verbose diagnosis or error cause, shown when a step fails (may be multi-line) |
+| `elapsedSec` | How long the step has taken: the whole span once done, or the time so far while running. A phase's figure is rolled up from its children |
+| `children` | The sub-steps of a phase |
+
+`message` moves as the work advances and is the line to show as "what is happening now";
+`detail` is the paragraph to show when something has gone wrong. The phase itself carries a
+static message (`precheck` → "Checking the environment"); the line that actually changes is on
+the running sub-step, so a live status display should read the deepest running node.
+
+### The phases and their sub-steps
+
+All six phases are seeded when the run starts, so the whole outline is visible from the first
+read. Sub-steps appear under the phases that report them; the other phases record at the phase
+level only.
+
+| Phase (`name`) | Sub-steps (`children[].name`) | Notes |
+|---|---|---|
+| `precheck` | `target_exists`, `target_running`, `target_reachable`, `metric_port_open`, `remote_command` | `metric_port_open` only when *Collect Additional System Metrics* is on, else `skipped` |
+| `generator_install` | `reachable` | Sub-step only when reusing a remote generator; a fresh install records at the phase level |
+| `agent_install` | `install`, `process_up`, `port_reachable` | The whole phase runs only when metrics are on, else `skipped` |
+| `jmx_prepare` | — | Phase level only |
+| `jmeter_run` | — | Phase level only. This is the timed load; use `elapsedSec` against `totalExpectedExecutionSecond` for its progress |
+| `result_fetch` | `file_result`, `file_cpu`, `file_memory`, `file_disk`, `file_network` | The metric files only when metrics are on; `file_result` always. See [Result collection](#result-collection) |
+
+A phase with no sub-steps shows its own status only. A run that has not reached a phase leaves
+it `pending`.
+
+## Result collection
+
+Result collection used to be one opaque `result_fetch` step, so a run whose results took far
+longer than the 30-second load gave no clue which file it was waiting on. Each result file is
+now its own sub-step: it starts `running` ("Waiting for the … file"), turns `ok` when it lands
+("… collected"), and turns `skipped` if it never arrives within the wait window. The load
+result failing fails the step; a missing metric file only costs its chart, so it is skipped
+rather than failed. Because the number of files is fixed, a client can show collection as a
+percentage of files received.
+
+The files are pulled with rsync while they are still being written on the generator, so the
+metric files routinely land after the main result — hence the waiting and the retries. What a
+long wait on a file usually means is that the file has not been produced yet, not that the
+transfer is slow.
+
+## Reading the last configuration (Re-run)
+
+`GET /api/v1/load/tests/infos/{loadTestKey}` (operationId `GetLoadTestExecutionInfo`) returns
+the parameters a run was started with — scenario name, virtual users, duration, ramp-up, and
+the HTTP request. A client uses it to pre-fill the form for a re-run.
+
+The configuration is recorded **before** the pre-check runs, so a run that fails in the
+pre-check still has its parameters on record and can be re-run from any client. (Earlier the
+record was written only after pre-check and generator install had both succeeded, so a
+pre-check failure left nothing to read and this call answered 500.) The generator is linked to
+the record after it is installed; until then the record simply has no generator.

--- a/internal/core/load/load_test_execution_service.go
+++ b/internal/core/load/load_test_execution_service.go
@@ -253,6 +253,46 @@ func (l *LoadService) processLoadTestAsync(param RunLoadTestParam, loadTestExecu
 		loadTestExecutionState.FinishAt = &finishAt
 	}
 
+	// Persist the requested configuration up front, before anything can fail. A run that dies in
+	// pre-check or generator install used to leave no info row at all, because the save happened
+	// only after both succeeded — so GetLoadTestExecutionInfo (which Re-run reads to pre-fill the
+	// form) had nothing to return and answered 500. The parameters are known from the request, so
+	// record them now; the generator id is not known yet and is linked in after install.
+	var hs []LoadTestExecutionHttpInfo
+	for _, h := range param.HttpReqs {
+		hs = append(hs, LoadTestExecutionHttpInfo{
+			Method:   h.Method,
+			Protocol: h.Protocol,
+			Hostname: h.Hostname,
+			Port:     h.Port,
+			Path:     h.Path,
+			BodyData: h.BodyData,
+		})
+	}
+	loadTestExecutionInfoParam := LoadTestExecutionInfo{
+		LoadTestKey:  param.LoadTestKey,
+		TestName:     param.TestName,
+		VirtualUsers: param.VirtualUsers,
+		Duration:     param.Duration,
+		RampUpTime:   param.RampUpTime,
+		RampUpSteps:  param.RampUpSteps,
+
+		NsId:    param.NsId,
+		InfraId: param.InfraId,
+		NodeId:  param.NodeId,
+
+		AgentInstalled: param.CollectAdditionalSystemMetrics,
+		AgentHostname:  param.AgentHostname,
+
+		LoadTestExecutionHttpInfos: hs,
+		LoadTestExecutionStateId:   loadTestExecutionState.ID,
+	}
+	if err := l.loadRepo.SaveForLoadTestExecutionTx(context.Background(), &loadTestExecutionInfoParam); err != nil {
+		failed(fmt.Sprintf("Error saving load test execution info: %v", err), err)
+		return
+	}
+	loadTestExecutionState.TestExecutionInfoId = loadTestExecutionInfoParam.ID
+
 	// Check the environment before building anything (BAR-1553). A missing target or a closed
 	// port is answered in seconds here, instead of surfacing minutes into a run.
 	precheckCtx, cancelPrecheck := context.WithTimeout(context.Background(), 2*time.Minute)
@@ -311,50 +351,14 @@ func (l *LoadService) processLoadTestAsync(param RunLoadTestParam, loadTestExecu
 		return
 	}
 
-	var hs []LoadTestExecutionHttpInfo
-
-	for _, h := range param.HttpReqs {
-		hh := LoadTestExecutionHttpInfo{
-			Method:   h.Method,
-			Protocol: h.Protocol,
-			Hostname: h.Hostname,
-			Port:     h.Port,
-			Path:     h.Path,
-			BodyData: h.BodyData,
-		}
-
-		hs = append(hs, hh)
-	}
-
-	loadTestExecutionInfoParam := LoadTestExecutionInfo{
-		LoadTestKey:  param.LoadTestKey,
-		TestName:     param.TestName,
-		VirtualUsers: param.VirtualUsers,
-		Duration:     param.Duration,
-		RampUpTime:   param.RampUpTime,
-		RampUpSteps:  param.RampUpSteps,
-
-		NsId:    param.NsId,
-		InfraId: param.InfraId,
-		NodeId:  param.NodeId,
-
-		AgentInstalled: param.CollectAdditionalSystemMetrics,
-		AgentHostname:  param.AgentHostname,
-
-		LoadGeneratorInstallInfoId: loadGeneratorInstallInfo.ID,
-		LoadTestExecutionHttpInfos: hs,
-
-		LoadTestExecutionStateId: loadTestExecutionState.ID,
-	}
-
-	err = l.loadRepo.SaveForLoadTestExecutionTx(context.Background(), &loadTestExecutionInfoParam)
-	if err != nil {
-		failed(fmt.Sprintf("Error saving load test execution info: %v", err), err)
+	// The generator exists now; link the info row saved earlier to it. TestExecutionInfoId was
+	// already set from the early save above.
+	if err = l.loadRepo.UpdateLoadTestExecutionInfoGeneratorTx(context.Background(), param.LoadTestKey, loadGeneratorInstallInfo.ID); err != nil {
+		failed(fmt.Sprintf("Error linking load test execution info to the generator: %v", err), err)
 		return
 	}
-
+	loadTestExecutionInfoParam.LoadGeneratorInstallInfoId = loadGeneratorInstallInfo.ID
 	loadTestExecutionState.GeneratorInstallInfoId = loadGeneratorInstallInfo.ID
-	loadTestExecutionState.TestExecutionInfoId = loadTestExecutionInfoParam.ID
 
 	err = l.loadRepo.UpdateLoadTestExecutionStateTx(context.Background(), loadTestExecutionState)
 

--- a/internal/core/load/load_test_execution_service.go
+++ b/internal/core/load/load_test_execution_service.go
@@ -357,7 +357,6 @@ func (l *LoadService) processLoadTestAsync(param RunLoadTestParam, loadTestExecu
 		failed(fmt.Sprintf("Error linking load test execution info to the generator: %v", err), err)
 		return
 	}
-	loadTestExecutionInfoParam.LoadGeneratorInstallInfoId = loadGeneratorInstallInfo.ID
 	loadTestExecutionState.GeneratorInstallInfoId = loadGeneratorInstallInfo.ID
 
 	err = l.loadRepo.UpdateLoadTestExecutionStateTx(context.Background(), loadTestExecutionState)

--- a/internal/core/load/models.go
+++ b/internal/core/load/models.go
@@ -152,8 +152,11 @@ type LoadTestExecutionInfo struct {
 	LoadTestExecutionStateId uint
 	LoadTestExecutionState   LoadTestExecutionState
 
-	// LoadTestExecutionInfo has one LoadGeneratorInstallInfo
-	LoadGeneratorInstallInfoId uint
+	// LoadTestExecutionInfo has one LoadGeneratorInstallInfo. Nullable: the config row is now
+	// written before the generator exists (so a run that fails in pre-check still records its
+	// parameters for Re-run), and is linked to the generator once it is installed. A non-null
+	// uint would default to 0 and violate the foreign key on that early insert.
+	LoadGeneratorInstallInfoId *uint
 	LoadGeneratorInstallInfo   LoadGeneratorInstallInfo
 }
 

--- a/internal/core/load/repository.go
+++ b/internal/core/load/repository.go
@@ -351,6 +351,19 @@ func (r *LoadRepository) UpdateLoadTestExecutionInfoDuration(ctx context.Context
 
 }
 
+// UpdateLoadTestExecutionInfoGeneratorTx links the info row to the generator once it is known.
+// The requested configuration is persisted up front, before the generator exists, so a run
+// that fails in pre-check still has its parameters on record; this fills in the generator id
+// afterwards without disturbing the parameters already saved.
+func (r *LoadRepository) UpdateLoadTestExecutionInfoGeneratorTx(ctx context.Context, loadTestKey string, loadGeneratorInstallInfoId uint) error {
+	return r.execInTransaction(ctx, func(d *gorm.DB) error {
+		return d.
+			Model(&LoadTestExecutionInfo{}).
+			Where("load_test_key = ?", loadTestKey).
+			Update("load_generator_install_info_id", loadGeneratorInstallInfoId).Error
+	})
+}
+
 func (r *LoadRepository) GetPagingLoadTestExecutionStateTx(ctx context.Context, param GetAllLoadTestExecutionStateParam) ([]LoadTestExecutionState, int64, error) {
 	var loadTestExecutionStates []LoadTestExecutionState
 	var totalRows int64

--- a/internal/core/load/rsync_fetch_service.go
+++ b/internal/core/load/rsync_fetch_service.go
@@ -107,11 +107,19 @@ func (l *LoadService) fetchData(f *fetchDataParam) {
 // It returns as soon as everything is in. Otherwise it keeps going while progress is being
 // made - each round that brings a new file earns another round - and stops once a whole round
 // adds nothing, or when the overall deadline passes.
+//
+// Each result file is recorded as its own sub-step (BAR: result-fetch granularity), so a
+// collection that sits for a long time shows exactly which file it is still waiting on rather
+// than one opaque "Collecting results". A 30s run whose results take far longer is almost
+// always waiting on a specific metric csv here, and that file is now named as it waits.
 func (l *LoadService) collectResults(f *fetchDataParam) (fetchOutcome, error) {
 	deadline := time.Now().Add(resultCollectWindow)
 	var outcome fetchOutcome
 	var err error
 	previousMissing := -1
+
+	// Name every file we expect up front so the console draws the whole set from the first poll.
+	f.beginResultFileSteps()
 
 	for round := 1; ; round++ {
 		if f.isRunning() {
@@ -122,8 +130,13 @@ func (l *LoadService) collectResults(f *fetchDataParam) (fetchOutcome, error) {
 		outcome, err = rsyncFiles(f)
 		if err != nil {
 			log.Error().Msgf("error while fetching data from rsync %s", err.Error())
+			f.recordStep(constant.SubFileResult, "failed", "Load result file not collected", err.Error())
 			return outcome, err
 		}
+		// The main file is in (err == nil); flip it and any metric files that have arrived to ok,
+		// and leave the rest waiting with the round they are on.
+		f.recordResultFileProgress(outcome, round)
+
 		if len(outcome.MissingMetrics) == 0 {
 			return outcome, nil
 		}
@@ -133,6 +146,8 @@ func (l *LoadService) collectResults(f *fetchDataParam) (fetchOutcome, error) {
 
 		if !madeProgress || time.Now().After(deadline) {
 			log.Warn().Msgf("giving up on metric files after %d rounds: %v", round, outcome.MissingMetrics)
+			// The load figures are in; the missing metric files only cost their charts.
+			f.skipMissingMetricFiles(outcome)
 			return outcome, nil
 		}
 
@@ -140,6 +155,107 @@ func (l *LoadService) collectResults(f *fetchDataParam) (fetchOutcome, error) {
 			fmt.Sprintf("Collecting results - still waiting for %s", strings.Join(outcome.MissingMetrics, ", ")),
 			"metric files are written during the run and can arrive after the main result")
 		time.Sleep(resultCollectInterval)
+	}
+}
+
+// resultFilePrefixes lists the rsync prefixes this run collects: the main result, plus the
+// metric files when additional system metrics were requested. It matches rsyncFiles exactly.
+func (f *fetchDataParam) resultFilePrefixes() []string {
+	prefixes := []string{""}
+	if f.CollectAdditionalSystemMetrics {
+		prefixes = append(prefixes, "_cpu", "_disk", "_memory", "_network")
+	}
+	return prefixes
+}
+
+// resultFileStep maps an rsync prefix to its sub-step name.
+func resultFileStep(prefix string) constant.ExecutionStep {
+	switch prefix {
+	case "":
+		return constant.SubFileResult
+	case "_cpu":
+		return constant.SubFileCpu
+	case "_disk":
+		return constant.SubFileDisk
+	case "_memory":
+		return constant.SubFileMemory
+	case "_network":
+		return constant.SubFileNetwork
+	}
+	return ""
+}
+
+// resultFileLabel is the human name for a result file, used in the step message.
+func resultFileLabel(prefix string) string {
+	switch prefix {
+	case "":
+		return "load result"
+	case "_cpu":
+		return "cpu metrics"
+	case "_disk":
+		return "disk metrics"
+	case "_memory":
+		return "memory metrics"
+	case "_network":
+		return "network metrics"
+	}
+	return strings.TrimPrefix(prefix, "_")
+}
+
+// recordStep is a nil-safe helper for the file sub-steps.
+func (f *fetchDataParam) recordStep(name constant.ExecutionStep, status, message, detail string) {
+	if f.StepRec == nil || name == "" {
+		return
+	}
+	switch status {
+	case "ok":
+		f.StepRec.ok(name, message)
+	case "failed":
+		f.StepRec.fail(name, message, detail)
+	case "skipped":
+		f.StepRec.skip(name, message)
+	default:
+		f.StepRec.begin(name, message)
+	}
+}
+
+// beginResultFileSteps marks every expected file as waiting, so the set is visible from the start.
+func (f *fetchDataParam) beginResultFileSteps() {
+	for _, p := range f.resultFilePrefixes() {
+		f.recordStep(resultFileStep(p), "running", "Waiting for the "+resultFileLabel(p)+" file", "")
+	}
+}
+
+// recordResultFileProgress flips the files that have arrived to ok and leaves the rest waiting.
+func (f *fetchDataParam) recordResultFileProgress(outcome fetchOutcome, round int) {
+	if f.StepRec == nil {
+		return
+	}
+	missing := map[string]bool{}
+	for _, m := range outcome.MissingMetrics {
+		missing[m] = true
+	}
+	for _, p := range f.resultFilePrefixes() {
+		metric := strings.TrimPrefix(p, "_")
+		if p == "" {
+			f.StepRec.ok(constant.SubFileResult, "Load result file collected")
+			continue
+		}
+		if missing[metric] {
+			f.StepRec.progress(resultFileStep(p), round,
+				fmt.Sprintf("Waiting for the %s file (round %d)", resultFileLabel(p), round),
+				"written on the generator during the run; can arrive after the load result")
+		} else {
+			f.StepRec.ok(resultFileStep(p), resultFileLabel(p)+" collected")
+		}
+	}
+}
+
+// skipMissingMetricFiles records the metric files that never arrived. They are skipped, not
+// failed: the run stands on its load result and only loses those charts (BAR-1552).
+func (f *fetchDataParam) skipMissingMetricFiles(outcome fetchOutcome) {
+	for _, metric := range outcome.MissingMetrics {
+		f.recordStep(resultFileStep("_"+metric), "skipped", resultFileLabel("_"+metric)+" not collected in time", "")
 	}
 }
 


### PR DESCRIPTION
A load test's progress is shown in the console as a phase/sub-step tree. Two backend gaps surfaced while using it.

## The requested config is recorded up front

cm-ant recorded a run's requested configuration (LoadTestExecutionInfo) only after pre-check and generator install had both succeeded, so a run that failed in pre-check lost what was requested — the record was never written, and GetLoadTestExecutionInfo returned 500. RunLoadTest now records the requested config right after seeding the steps, before pre-check, so a run's configuration can be read back through GetLoadTestExecutionInfo regardless of how the run turns out. The generator is linked to the record after it is installed; the generator reference (LoadGeneratorInstallInfoId) is nullable so the early save can proceed before a generator exists.

## Result collection is reported per file

Result collection was one opaque step, so a run whose results took far longer than the load itself gave no clue which file it was waiting on (rsync keeps retrying even when a file does not exist yet). Each result file is now its own sub-step — load result, cpu, memory, disk, network: waiting while it has not arrived, ok as it lands, skipped if it never comes within the window. The load result failing fails the step; a missing metric file only costs its chart. The file count is fixed, so a consumer can show collection as a percentage.

Docs: docs/load-test-status-api.md describes the status/steps response and this behavior.